### PR TITLE
Stencil <: StaticVector

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Exeample: mean blur, benchmarked on an 8-core thinkpad:
 ```julia
 using Stencils, Statistics, BenchmarkTools
 r = rand(1000, 1000)
-A = StencilArray(r, Window{1,2}())
+A = StencilArray(r, Window(1))
 @benchmark broadcast_stencil(mean, A)
 
 # Output:

--- a/src/Stencils.jl
+++ b/src/Stencils.jl
@@ -19,17 +19,17 @@ export stencil, neighbors, offsets, indices, distances, radius, diameter, kernel
 export broadcast_stencil, broadcast_stencil!
 
 include("stencil.jl")
-include("boundary.jl")
-include("padding.jl")
-include("array.jl")
-include("broadcast_stencil.jl")
-
 include("stencils/window.jl")
 include("stencils/moore.jl")
 include("stencils/vonneumman.jl")
 include("stencils/positional.jl")
 include("stencils/layered.jl")
 include("stencils/kernel.jl")
+
+include("boundary.jl")
+include("padding.jl")
+include("array.jl")
+include("broadcast_stencil.jl")
 
 end # Module Stencils
 

--- a/src/broadcast_stencil.jl
+++ b/src/broadcast_stencil.jl
@@ -19,14 +19,8 @@ function broadcast_stencil(f, source::AbstractStencilArray{<:Any,<:Any,T,N}, arg
     dest = similar(parent(source), T_return, size(source))
     broadcast_stencil!(f, dest, source, args...)
 end
-broadcast_stencil(f, hood::Stencil, A::AbstractArray, args::AbstractArray...; kw...) =
+broadcast_stencil(f, hood::StencilOrLayered, A::AbstractArray, args::AbstractArray...; kw...) =
     broadcast_stencil(f, StencilArray(A, hood; kw...), args...)
-
-_emptyhood(x) = _emptyhood(x, stencil(x))
-function _emptyhood(x::AbstractArray{T}, hood::Stencil{<:Any,<:Any,L}) where {T,L} 
-    z = zero(T)
-    return SVector(ntuple(_ -> z, Val{L}()))
-end
 
 kernel_setup() = KernelAbstractions.CPU(), 1
 

--- a/src/padding.jl
+++ b/src/padding.jl
@@ -100,8 +100,8 @@ $RADIUSDOC
 
 `padval` defaults to `zero(eltype(A))`.
 """
-pad_array(::Conditional, ::BoundaryCondition, hood::Stencil, parent::AbstractArray) = parent
-function pad_array(::Halo{:out}, bc::BoundaryCondition, hood::Stencil, parent::AbstractArray{T}) where T
+pad_array(::Conditional, ::BoundaryCondition, hood::StencilOrLayered, parent::AbstractArray) = parent
+function pad_array(::Halo{:out}, bc::BoundaryCondition, hood::StencilOrLayered, parent::AbstractArray{T}) where T
     rs = _radii(parent, hood)
     padded_axes = outer_axes(parent, rs)
     padded_parent = similar(parent, T, length.(padded_axes))
@@ -109,6 +109,6 @@ function pad_array(::Halo{:out}, bc::BoundaryCondition, hood::Stencil, parent::A
     padded_offset = OffsetArray(padded_parent, padded_axes)
     return padded_offset
 end
-function pad_array(::Halo{:in}, bc::BoundaryCondition, hood::Stencil, parent::AbstractArray)
+function pad_array(::Halo{:in}, bc::BoundaryCondition, hood::StencilOrLayered, parent::AbstractArray)
     return OffsetArray(parent, offset_axes(parent, hood))
 end

--- a/src/stencils/kernel.jl
+++ b/src/stencils/kernel.jl
@@ -6,10 +6,10 @@ Abstract supertype for kernel stencils.
 These can wrap any other stencil object, and include a kernel of
 the same length and positions as the stencil.
 """
-abstract type AbstractKernelStencil{R,N,L,H} <: Stencil{R,N,L} end
+abstract type AbstractKernelStencil{R,N,L,T,H} <: Stencil{R,N,L,T} end
 
 neighbors(hood::AbstractKernelStencil) = neighbors(stencil(hood))
-offsets(::Type{<:AbstractKernelStencil{<:Any,<:Any,<:Any,H}}) where H = offsets(H)
+offsets(::Type{<:AbstractKernelStencil{<:Any,<:Any,<:Any,<:Any,H}}) where H = offsets(H)
 positions(hood::AbstractKernelStencil, I::Tuple) = positions(stencil(hood), I)
 
 """
@@ -64,25 +64,25 @@ end
 Wrap any other stencil object, and includes a kernel of
 the same length and positions as the stencil.
 """
-struct Kernel{R,N,L,H,K} <: AbstractKernelStencil{R,N,L,H}
+struct Kernel{R,N,L,T,H,K} <: AbstractKernelStencil{R,N,L,T,H}
     stencil::H
     kernel::K
 end
 Kernel(A::AbstractMatrix) = Kernel(Window(A), A)
-function Kernel(hood::H, kernel::K) where {H<:Stencil{R,N,L},K} where {R,N,L}
+function Kernel(hood::H, kernel::K) where {H<:Stencil{R,N,L,T},K} where {R,N,L,T}
     length(hood) == length(kernel) || _kernel_length_error(hood, kernel)
-    Kernel{R,N,L,H,K}(hood, kernel)
+    Kernel{R,N,L,T,H,K}(hood, kernel)
 end
-function Kernel{R,N,L}(hood::H, kernel::K) where {R,N,L,H<:Stencil{R,N,L},K}
-    Kernel{R,N,L,H,K}(hood, kernel)
+function Kernel{R,N,L,T}(hood::H, kernel::K) where {R,N,L,H<:Stencil{R,N,L,T},K} where T
+    Kernel{R,N,L,T,H,K}(hood, kernel)
 end
 
 function _kernel_length_error(hood, kernel)
     throw(ArgumentError("Stencil length $(length(hood)) does not match kernel length $(length(kernel))"))
 end
 
-function setneighbors(n::Kernel{R,N,L,<:Any,K}, _neighbors) where {R,N,L,K}
-    hood = setneighbors(stencil(n), _neighbors)
-    return Kernel{R,N,L,typeof(hood),K}(hood, kernel(n))
+function setneighbors(n::Kernel{R,N,L,<:Any,<:Any,K}, neighbors) where {R,N,L,K}
+    hood = setneighbors(stencil(n), neighbors)
+    return Kernel{R,N,L,eltype(hood),typeof(hood),K}(hood, kernel(n))
 end
 

--- a/src/stencils/layered.jl
+++ b/src/stencils/layered.jl
@@ -8,41 +8,38 @@
 `neighbors` for `Layered` returns a tuple of iterators
 for each stencil layer.
 """
-struct Layered{R,N,L,La} <: Stencil{R,N,L}
+struct Layered{R,N,L,T,La}
     "A tuple of custom stencils"
     layers::La
 end
-Layered(layers::Stencil...) = Layered(layers)
-function Layered(layers::Union{NamedTuple,Tuple}, _neighbors=nothing)
-    N = ndims(first(layers))
-    R = if length(layers) > 1
-        layer_radii = map(l -> _radii(Val{N}(), l), layers)
-        # Find the maximum bounds of each dimension
-        reduce(layer_radii) do acc, next
-            map(acc, next) do a, n
-                min(a[1], n[1]), max(a[2], n[2])
-            end
-        end
-    else
-        radius(first(layers))
-    end
+Layered{R,N,L,T}(layers) where {R,N,L,T} = Layered{R,N,L,T,typeof(layers)}(layers)
+Layered{R,N,L}(layers) where {R,N,L} = Layered{R,N,L,eltype(first(layers))}(layers)
+
+const StencilOrLayered = Union{Stencil,Layered}
+
+Layered(layers::StencilOrLayered...) = Layered(layers)
+function Layered(layers::Union{NamedTuple,Tuple})
+    N = ndimensions(first(layers))
+    R = maximum(map(radius, layers))
     L = map(length, layers)
     Layered{R,N,L}(layers)
 end
-Layered{R,N,L}(layers) where {R,N,L} = Layered{R,N,L,typeof(layers)}(layers)
-Layered(; layers...) = Layered(values(layers))
 
-layers(hood::Layered) = hood.layers
-@inline neighbors(hood::Layered) = map(l -> neighbors(l), hood.layers)
-@inline offsets(::Type{<:Layered{R,N,L,La}}) where {R,N,L,La} =
+layers(stencil::Layered) = stencil.layers
+@inline offsets(::Type{<:Layered{R,N,L,T,La}}) where {R,N,L,T,La} =
     map(p -> offsets(p), tuple_contents(La))
-@inline indices(hood::Layered, I::Tuple) = map(l -> indices(l, I...), hood.layers)
-@inline function setneighbors(h::Layered{R,N,L}, layer_neighbors) where {R,N,L}
-    Layered{R,N,L}(map(setneighbors, layers(h), layer_neighbors))
+
+@inline function setneighbors(h::Layered{R,N,L,T}, layerneighbors) where {R,N,L,T}
+    Layered{R,N,L,T}(map(setneighbors, layers(h), layerneighbors))
 end
 
-@inline function unsafe_neighbors(A::AbstractStencilArray, hood::Layered, I::CartesianIndex)
-    map(l -> unsafe_neighbors(A, l, I), layers(hood))
+for f in (:neighbors, :offsets, :cartesian_offsets, :distances, :distance_zones)
+    @eval $f(layered::Layered) = map($f, layered)
 end
 
-Base.map(f, hood::Layered) = map(f, layers(hood))
+radius(layered::Layered{R}) where R = R
+ndimensions(layered::Layered{<:Any,N}) where N = N
+indices(layered::Layered, I) = map(l -> indices(l, I), layered)
+
+Base.map(f, stencil::Layered) = map(f, layers(stencil))
+


### PR DESCRIPTION
This PR makes all stencils `<: StaticVector`, except `Layered` which is now not a `Stencil` but a collection of `Stencil`.

Stangely `getindex` is not currently type stable in all situations, so the expected (small) perfomance improvement of doing this isn't always seen.

Edit: mostly it seems better, there may be some additional methods to add to avoid fallbacks sometimes, but otherwise this is an improvement.

Closes #10 