### PR TITLE
simpilfy API methods and internals

### DIFF
--- a/src/Stencils.jl
+++ b/src/Stencils.jl
@@ -16,7 +16,8 @@ export StencilArray
 export BoundaryCondition, Wrap, Remove
 export Padding, Conditional, Halo
 
-export stencil, neighbors, offsets, indices, distances, radius, diameter, kernel, kernelproduct
+export stencil, neighbors, offsets, indices, distances, distance_zones, radius, 
+    diameter, kernel, kernelproduct
 export mapstencil, mapstencil!
 
 include("stencil.jl")

--- a/src/mapstencil.jl
+++ b/src/mapstencil.jl
@@ -13,7 +13,7 @@ function mapstencil(f, source::AbstractStencilArray{<:Any,<:Any,T,N}, args::Abst
     T1 = bc isa Remove ? promote_type(T, typeof(padval(bc))) : T
     L = length(stencil(source))
     emptyneighbors = SVector{L,T}(ntuple(_ -> zero(T), L))
-    H = typeof(setneighbors(stencil(source), emptyneighbors))
+    H = typeof(rebuild(stencil(source), emptyneighbors))
     # Use nasty broadcast mechanism `_return_type` to get the new eltype
     T_return = Base._return_type(f, Tuple{H,map(eltype, args)...})
     dest = similar(parent(source), T_return, size(source))

--- a/src/stencil.jl
+++ b/src/stencil.jl
@@ -48,11 +48,11 @@ function neighbors end
 neighbors(hood::Stencil) = hood.neighbors
 
 """
-    setneighbors(x::Stencil, neighbors::StaticArray)
+    rebuild(x::Stencil, neighbors::StaticArray)
 
-Update the eighbors of a `Stencil`, returning and identical object with new values.
+Rebuild a a `Stencil`, returning and identical object with new values.
 """
-function setneighbors end
+function rebuild end
 
 """
     offsets(x) -> iterable
@@ -215,7 +215,7 @@ macro stencil(name, description)
         $name(args::StaticVector...; radius=1, ndims=2) = $name{radius,ndims}(args...)
         $name(radius::Int, ndims::Int=2) = $name{radius,ndims}()
 
-        @inline Stencils.setneighbors(n::$name{R,N,L}, neighbors) where {R,N,L} = $name{R,N,L}(neighbors)
+        @inline Stencils.rebuild(n::$name{R,N,L}, neighbors) where {R,N,L} = $name{R,N,L}(neighbors)
     end
     return Expr(:block, :(Base.@doc $docstring $struct_expr), func_exprs)
 end

--- a/src/stencils/kernel.jl
+++ b/src/stencils/kernel.jl
@@ -81,8 +81,8 @@ function _kernel_length_error(hood, kernel)
     throw(ArgumentError("Stencil length $(length(hood)) does not match kernel length $(length(kernel))"))
 end
 
-function setneighbors(n::Kernel{R,N,L,<:Any,<:Any,K}, neighbors) where {R,N,L,K}
-    hood = setneighbors(stencil(n), neighbors)
+function rebuild(n::Kernel{R,N,L,<:Any,<:Any,K}, neighbors) where {R,N,L,K}
+    hood = rebuild(stencil(n), neighbors)
     return Kernel{R,N,L,eltype(hood),typeof(hood),K}(hood, kernel(n))
 end
 

--- a/src/stencils/layered.jl
+++ b/src/stencils/layered.jl
@@ -29,8 +29,8 @@ layers(stencil::Layered) = stencil.layers
 @inline offsets(::Type{<:Layered{R,N,L,T,La}}) where {R,N,L,T,La} =
     map(p -> offsets(p), tuple_contents(La))
 
-@inline function setneighbors(h::Layered{R,N,L,T}, layerneighbors) where {R,N,L,T}
-    Layered{R,N,L,T}(map(setneighbors, layers(h), layerneighbors))
+@inline function rebuild(h::Layered{R,N,L,T}, layerneighbors) where {R,N,L,T}
+    Layered{R,N,L,T}(map(rebuild, layers(h), layerneighbors))
 end
 
 for f in (:neighbors, :offsets, :cartesian_offsets, :distances, :distance_zones)

--- a/src/stencils/positional.jl
+++ b/src/stencils/positional.jl
@@ -74,7 +74,7 @@ end
 
 offsets(::Type{<:Positional{O}}) where O = SVector(O)
 
-@inline function setneighbors(n::Positional{O,R,N,L}, neighbors) where {O,R,N,L}
+@inline function rebuild(n::Positional{O,R,N,L}, neighbors) where {O,R,N,L}
     Positional{O,R,N,L}(neighbors)
 end
 

--- a/test/stencils.jl
+++ b/test/stencils.jl
@@ -1,5 +1,4 @@
 using Stencils, Test, LinearAlgebra, StaticArrays, OffsetArrays, BenchmarkTools
-using Stencils: setneighbors
 
 init = [0 0 0 1 1 1
         1 0 1 1 0 1
@@ -34,7 +33,8 @@ win3 = SA[1, 1, 1, 0, 0, 1, 0, 0, 1]
 end
 
 @testset "Window" begin
-    @test Window{1}() == Window{1,2}() == Window(zeros(3, 3))
+    @test Window{1}() == Window{1,2}() == 
+    Window(zeros(3, 3))
     window = Window{1}(SVector(init[1:3, 1:3]...))
     @test isbits(window)
     @test diameter(window) == 3
@@ -47,7 +47,7 @@ end
     @test offsets(window) == SVector((-1, -1), (0, -1), (1, -1), (-1, 0), (0, 0),
                                      (1, 0), (-1, 1), (0, 1), (1, 1))
 
-    window2 = Stencils.setneighbors(window, SVector(win2...))
+    window2 = Stencils.rebuild(window, SVector(win2...))
     @test neighbors(window2) == SVector(win2...)
 
     @test sum(Window{1}(win1)) == 1
@@ -58,7 +58,7 @@ end
 @testset "VonNeumann" begin
     h = VonNeumann{1}()
     A = StencilArray(init, h)
-    vonneumann = Stencils.setneighbors(h, neighbors(A, (2, 2))) 
+    vonneumann = Stencils.rebuild(h, neighbors(A, (2, 2))) 
     @test offsets(vonneumann) == SVector((0, -1), (-1, 0), (1, 0), (0, 1))
     @test radius(vonneumann) == 1
     @test diameter(vonneumann) == 3
@@ -130,7 +130,7 @@ end
         off = ((0,-1),(-1,0),(1,0),(0,1))
         hood = Positional{off,1,2,4,}()
         vals = SVector(map(I -> win[I...], indices(hood, (2, 2))))
-        k = Stencils.setneighbors(Kernel(hood, 1:4), vals)
+        k = Stencils.rebuild(Kernel(hood, 1:4), vals)
         @test kernelproduct(k) === 1 * 2 + 2 * 4 + 3 * 6 + 4 * 8 === 60
     end
 end


### PR DESCRIPTION
This PR gets more out of the `stencil` method rather than having a separate `update_stencil`, and a few other simplifications flow from that.