### PR TITLE
Kernel fixes

### DIFF
--- a/src/Stencils.jl
+++ b/src/Stencils.jl
@@ -10,7 +10,7 @@ using Adapt,
 import SparseArrays
 
 export Stencil, Window, Kernel, Moore, VonNeumann, Positional, Layered, 
-    Circle, Cross, AngledCross, BackSlash, ForwardSlash, Vertical, Horizontal, NamedStencil
+    Circle, Cross, AngledCross, BackSlash, ForwardSlash, Vertical, Horizontal
 
 export StencilArray, SwitchingStencilArray
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -250,35 +250,35 @@ radii(x::Tuple, s::Tuple) = x
 
 
 # Base methods
-# function Base.copy!(S::AbstractStencilArray{<:Any,R}, A::AbstractArray) where R
-#     pad_axes = map(ax -> ax .+ R, axes(A))
-#     copyto!(parent(source(S)), CartesianIndices(pad_axes), A, CartesianIndices(A))
-#     return 
-# end
-# function Base.copy!(A::AbstractArray, S::AbstractStencilArray{<:Any,R}) where R
-#     pad_axes = map(ax -> ax .+ R, axes(A))
-#     copyto!(A, CartesianIndices(A), parent(source(S)), CartesianIndices(pad_axes))
-#     return A
-# end
-# function Base.copy!(dst::AbstractStencilArray{<:Any,RD}, src::AbstractStencilArray{<:Any,RS}) where {RD,RS}
-#     dst_axes = map(s -> RD:s + RD, size(dst))
-#     src_axes = map(s -> RS:s + RS, size(src))
-#     copyto!(parent(source(dst)), CartesianIndices(dst_axes),
-#             parent(source(src)), CartesianIndices(src_axes)
-#     )
-#     return dst
-# end
-# # Ambiguity
-# function copy!(S::AbstractStencilArray{<:Any,R,T,1} where T, A::AbstractVector) where R
-#     pad_axes = map(ax -> ax .+ R, axes(A))
-#     copyto!(parent(source(S)), CartesianIndices(pad_axes), A, CartesianIndices(A))
-#     return A
-# end
-# function copy!(A::AbstractVector, S::AbstractStencilArray{<:Any,R,T,1} where T) where R
-#     pad_axes = map(ax -> ax .+ R, axes(A))
-#     copyto!(A, CartesianIndices(A), parent(source(S)), CartesianIndices(pad_axes))
-#     return A
-# end
+function Base.copy!(S::AbstractStencilArray{<:Any,R}, A::AbstractArray) where R
+    pad_axes = map(ax -> ax .+ R, axes(A))
+    copyto!(parent(source(S)), CartesianIndices(pad_axes), A, CartesianIndices(A))
+    return 
+end
+function Base.copy!(A::AbstractArray, S::AbstractStencilArray{<:Any,R}) where R
+    pad_axes = map(ax -> ax .+ R, axes(A))
+    copyto!(A, CartesianIndices(A), parent(source(S)), CartesianIndices(pad_axes))
+    return A
+end
+function Base.copy!(dst::AbstractStencilArray{<:Any,RD}, src::AbstractStencilArray{<:Any,RS}) where {RD,RS}
+    dst_axes = map(s -> RD:s + RD, size(dst))
+    src_axes = map(s -> RS:s + RS, size(src))
+    copyto!(parent(source(dst)), CartesianIndices(dst_axes),
+            parent(source(src)), CartesianIndices(src_axes)
+    )
+    return dst
+end
+# Ambiguity
+function copy!(S::AbstractStencilArray{<:Any,R,T,1} where T, A::AbstractVector) where R
+    pad_axes = map(ax -> ax .+ R, axes(A))
+    copyto!(parent(source(S)), CartesianIndices(pad_axes), A, CartesianIndices(A))
+    return A
+end
+function copy!(A::AbstractVector, S::AbstractStencilArray{<:Any,R,T,1} where T) where R
+    pad_axes = map(ax -> ax .+ R, axes(A))
+    copyto!(A, CartesianIndices(A), parent(source(S)), CartesianIndices(pad_axes))
+    return A
+end
 # function copy!(A::SparseArrays.AbstractCompressedVector, S::AbstractStencilArray{<:Any,R,T,1} where T) where R
 #     pad_axes = map(ax -> ax .+ R, axes(A))
 #     copyto!(A, CartesianIndices(A), parent(source(S)), CartesianIndices(pad_axes))

--- a/src/array.jl
+++ b/src/array.jl
@@ -250,35 +250,35 @@ radii(x::Tuple, s::Tuple) = x
 
 
 # Base methods
-function Base.copy!(S::AbstractStencilArray{<:Any,R}, A::AbstractArray) where R
-    pad_axes = map(ax -> ax .+ R, axes(A))
-    copyto!(parent(source(S)), CartesianIndices(pad_axes), A, CartesianIndices(A))
-    return 
-end
-function Base.copy!(A::AbstractArray, S::AbstractStencilArray{<:Any,R}) where R
-    pad_axes = map(ax -> ax .+ R, axes(A))
-    copyto!(A, CartesianIndices(A), parent(source(S)), CartesianIndices(pad_axes))
-    return A
-end
-function Base.copy!(dst::AbstractStencilArray{<:Any,RD}, src::AbstractStencilArray{<:Any,RS}) where {RD,RS}
-    dst_axes = map(s -> RD:s + RD, size(dst))
-    src_axes = map(s -> RS:s + RS, size(src))
-    copyto!(parent(source(dst)), CartesianIndices(dst_axes),
-            parent(source(src)), CartesianIndices(src_axes)
-    )
-    return dst
-end
-# Ambiguity
-function copy!(S::AbstractStencilArray{<:Any,R,T,1} where T, A::AbstractVector) where R
-    pad_axes = map(ax -> ax .+ R, axes(A))
-    copyto!(parent(source(S)), CartesianIndices(pad_axes), A, CartesianIndices(A))
-    return A
-end
-function copy!(A::AbstractVector, S::AbstractStencilArray{<:Any,R,T,1} where T) where R
-    pad_axes = map(ax -> ax .+ R, axes(A))
-    copyto!(A, CartesianIndices(A), parent(source(S)), CartesianIndices(pad_axes))
-    return A
-end
+# function Base.copy!(S::AbstractStencilArray{<:Any,R}, A::AbstractArray) where R
+#     pad_axes = map(ax -> ax .+ R, axes(A))
+#     copyto!(parent(source(S)), CartesianIndices(pad_axes), A, CartesianIndices(A))
+#     return 
+# end
+# function Base.copy!(A::AbstractArray, S::AbstractStencilArray{<:Any,R}) where R
+#     pad_axes = map(ax -> ax .+ R, axes(A))
+#     copyto!(A, CartesianIndices(A), parent(source(S)), CartesianIndices(pad_axes))
+#     return A
+# end
+# function Base.copy!(dst::AbstractStencilArray{<:Any,RD}, src::AbstractStencilArray{<:Any,RS}) where {RD,RS}
+#     dst_axes = map(s -> RD:s + RD, size(dst))
+#     src_axes = map(s -> RS:s + RS, size(src))
+#     copyto!(parent(source(dst)), CartesianIndices(dst_axes),
+#             parent(source(src)), CartesianIndices(src_axes)
+#     )
+#     return dst
+# end
+# # Ambiguity
+# function copy!(S::AbstractStencilArray{<:Any,R,T,1} where T, A::AbstractVector) where R
+#     pad_axes = map(ax -> ax .+ R, axes(A))
+#     copyto!(parent(source(S)), CartesianIndices(pad_axes), A, CartesianIndices(A))
+#     return A
+# end
+# function copy!(A::AbstractVector, S::AbstractStencilArray{<:Any,R,T,1} where T) where R
+#     pad_axes = map(ax -> ax .+ R, axes(A))
+#     copyto!(A, CartesianIndices(A), parent(source(S)), CartesianIndices(pad_axes))
+#     return A
+# end
 # function copy!(A::SparseArrays.AbstractCompressedVector, S::AbstractStencilArray{<:Any,R,T,1} where T) where R
 #     pad_axes = map(ax -> ax .+ R, axes(A))
 #     copyto!(A, CartesianIndices(A), parent(source(S)), CartesianIndices(pad_axes))

--- a/src/stencil.jl
+++ b/src/stencil.jl
@@ -188,7 +188,6 @@ macro stencil(name, description)
         $name(; radius=1, ndims=2)
         $name(radius, ndims)
         $name{R,N}()
-        $name{R,N}()
 
     $description
     """

--- a/src/stencils/kernel.jl
+++ b/src/stencils/kernel.jl
@@ -60,8 +60,8 @@ struct Kernel{R,N,L,T,H,K} <: AbstractKernelStencil{R,N,L,T,H}
     stencil::H
     kernel::K
 end
-Kernel(A::AbstractArray) = Kernel(Window(A), A)
-Kernel(A::StaticArray) = Kernel(Window(A), A)
+Kernel(A::AbstractArray) = Kernel(Window{size(A)}(), A)
+Kernel(A::StaticArray) = Kernel(Window{size(A)}(), A)
 function Kernel(hood::H, kernel::K) where {H<:Stencil{R,N,L,T},K} where {R,N,L,T}
     length(hood) == length(kernel) || _kernel_length_error(hood, kernel)
     Kernel{R,N,L,T,H,K}(hood, kernel)

--- a/src/stencils/kernel.jl
+++ b/src/stencils/kernel.jl
@@ -60,8 +60,8 @@ struct Kernel{R,N,L,T,H,K} <: AbstractKernelStencil{R,N,L,T,H}
     stencil::H
     kernel::K
 end
-Kernel(A::AbstractArray) = Kernel(Window{size(A)}(), A)
-Kernel(A::StaticArray) = Kernel(Window{size(A)}(), A)
+Kernel(A::AbstractArray) = Kernel(Window{first(size(A)) ÷ 2,ndims(A)}(), A)
+Kernel(A::StaticArray) = Kernel(Window{first(size(A)) ÷ 2,ndims(A)}(), A)
 function Kernel(hood::H, kernel::K) where {H<:Stencil{R,N,L,T},K} where {R,N,L,T}
     length(hood) == length(kernel) || _kernel_length_error(hood, kernel)
     Kernel{R,N,L,T,H,K}(hood, kernel)

--- a/src/stencils/kernel.jl
+++ b/src/stencils/kernel.jl
@@ -60,7 +60,8 @@ struct Kernel{R,N,L,T,H,K} <: AbstractKernelStencil{R,N,L,T,H}
     stencil::H
     kernel::K
 end
-Kernel(A::AbstractMatrix) = Kernel(Window(A), A)
+Kernel(A::AbstractArray) = Kernel(Window(A), A)
+Kernel(A::StaticArray) = Kernel(Window(A), A)
 function Kernel(hood::H, kernel::K) where {H<:Stencil{R,N,L,T},K} where {R,N,L,T}
     length(hood) == length(kernel) || _kernel_length_error(hood, kernel)
     Kernel{R,N,L,T,H,K}(hood, kernel)

--- a/src/stencils/window.jl
+++ b/src/stencils/window.jl
@@ -1,8 +1,5 @@
 @stencil Window "A neighboorhood of radius R that includes the central cell."
 
-Window(A::AbstractArray) = Window{(size(A, 1) - 1) ÷ 2,ndims(A)}()
-Window(A::StaticArray) = Window{(size(A, 1) - 1) ÷ 2,ndims(A)}()
-
 # The central cell is included
 @generated function offsets(::Type{<:Window{R,N}}) where {R,N}
     D = 2R + 1

--- a/src/stencils/window.jl
+++ b/src/stencils/window.jl
@@ -1,6 +1,7 @@
 @stencil Window "A neighboorhood of radius R that includes the central cell."
 
 Window(A::AbstractArray) = Window{(size(A, 1) - 1) ÷ 2,ndims(A)}()
+Window(A::StaticArray) = Window{(size(A, 1) - 1) ÷ 2,ndims(A)}()
 
 # The central cell is included
 @generated function offsets(::Type{<:Window{R,N}}) where {R,N}

--- a/test/stencils.jl
+++ b/test/stencils.jl
@@ -33,10 +33,7 @@ win3 = SA[1, 1, 1, 0, 0, 1, 0, 0, 1]
 end
 
 @testset "Window" begin
-    @test Window{1}() == 
-        Window{1,2}() == 
-        Window(zeros(3, 3)) == 
-        Window(SMatrix{3,3}(zeros(3, 3)))
+    @test Window{1}() == Window{1,2}()
     window = Window{1}(SVector(init[1:3, 1:3]...))
     @test isbits(window)
     @test diameter(window) == 3
@@ -115,7 +112,6 @@ end
         kern = SVector{9}(1:9)
         Kernel(Window{1}(), kern)
         @test_throws ArgumentError Kernel(Window{2}(), kern)
-        @test Kernel(Window{1,2}(), SMatrix{3,3}(reshape(1:9, 3, 3))) == Kernel(SMatrix{3,3}(reshape(1:9, 3, 3)))
         k = Kernel(Window{1,2}(kern), SMatrix{3,3}(reshape(1:9, 3, 3)))
         @test kernelproduct(k) == sum((1:9).^2)
         @test neighbors(k) == SVector{9}(1:9)

--- a/test/stencils.jl
+++ b/test/stencils.jl
@@ -33,8 +33,10 @@ win3 = SA[1, 1, 1, 0, 0, 1, 0, 0, 1]
 end
 
 @testset "Window" begin
-    @test Window{1}() == Window{1,2}() == 
-    Window(zeros(3, 3))
+    @test Window{1}() == 
+        Window{1,2}() == 
+        Window(zeros(3, 3)) == 
+        Window(SMatrix{3,3}(zeros(3, 3)))
     window = Window{1}(SVector(init[1:3, 1:3]...))
     @test isbits(window)
     @test diameter(window) == 3
@@ -113,6 +115,7 @@ end
         kern = SVector{9}(1:9)
         Kernel(Window{1}(), kern)
         @test_throws ArgumentError Kernel(Window{2}(), kern)
+        @test Kernel(Window{1,2}(), SMatrix{3,3}(reshape(1:9, 3, 3))) == Kernel(SMatrix{3,3}(reshape(1:9, 3, 3)))
         k = Kernel(Window{1,2}(kern), SMatrix{3,3}(reshape(1:9, 3, 3)))
         @test kernelproduct(k) == sum((1:9).^2)
         @test neighbors(k) == SVector{9}(1:9)

--- a/test/stencils.jl
+++ b/test/stencils.jl
@@ -112,6 +112,9 @@ end
         kern = SVector{9}(1:9)
         Kernel(Window{1}(), kern)
         @test_throws ArgumentError Kernel(Window{2}(), kern)
+        @test Kernel(Window{1,2}(), SMatrix{3,3}(reshape(1:9, 3, 3))) == 
+            Kernel(SMatrix{3,3}(reshape(1:9, 3, 3)))
+            Kernel(reshape(1:9, 3, 3))
         k = Kernel(Window{1,2}(kern), SMatrix{3,3}(reshape(1:9, 3, 3)))
         @test kernelproduct(k) == sum((1:9).^2)
         @test neighbors(k) == SVector{9}(1:9)


### PR DESCRIPTION
Fix and test creating `Kernel` from an array

Removes the `Array` constrctor for `Window` because its pretty confusing. This is breaking.