### PR TITLE
allow stencil N smaller than array N

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -26,7 +26,7 @@ Base.@propagate_inbounds stencil(A::AbstractStencilArray, I::Union{CartesianInde
 Base.@propagate_inbounds stencil(A::AbstractStencilArray, I::CartesianIndex) =
     stencil(stencil(A), A, I)
 Base.@propagate_inbounds stencil(hood::StencilOrLayered, A::AbstractStencilArray, I::CartesianIndex) =
-    rebuild(stencil(A), neighbors(A, I))
+    rebuild(hood, neighbors(hood, A, I))
 Base.@propagate_inbounds stencil(A::AbstractStencilArray) = A.stencil
 
 """
@@ -362,7 +362,7 @@ with neighbors:
  192
 ```
 """
-struct StencilArray{S,R,T,N,A<:AbstractArray{T,N},H<:Union{Stencil{R,N},Layered{R,N}},BC,P} <: AbstractStencilArray{S,R,T,N,A,H,BC,P}
+struct StencilArray{S,R,T,N,A<:AbstractArray{T,N},H<:Union{Stencil{R},Layered{R}},BC,P} <: AbstractStencilArray{S,R,T,N,A,H,BC,P}
     parent::A
     stencil::H
     boundary::BC
@@ -454,7 +454,7 @@ end
 
 ```
 """
-struct SwitchingStencilArray{S,R,T,N,A<:AbstractArray{T,N},H<:Union{Stencil{R,N},Layered{R,N}},BC,P} <: AbstractSwitchingStencilArray{S,R,T,N,A,H,BC,P}
+struct SwitchingStencilArray{S,R,T,N,A<:AbstractArray{T,N},H<:Union{Stencil{R},Layered{R}},BC,P} <: AbstractSwitchingStencilArray{S,R,T,N,A,H,BC,P}
     source::A
     dest::A
     stencil::H

--- a/src/stencil.jl
+++ b/src/stencil.jl
@@ -80,7 +80,12 @@ Returns an `SVector` of `CartesianIndices` for each neighbor around `I`.
 function indices end
 @inline indices(hood::Stencil, I::CartesianIndex) = indices(hood, Tuple(I))
 @inline indices(hood::Stencil, I::Int...) = indices(hood, I)
-@inline indices(hood::Stencil, I) = map(O -> map(+, O, I), offsets(hood))
+# Allow trailing indices - we can use a Stencil with N smaller than the array N
+@inline function indices(hood::Stencil{<:Any,N1}, I::NTuple{N2}) where {N1,N2} 
+    map(I1 -> (I1..., I[N1+1:N2]...), indices(hood, I[1:N1])) 
+end
+@inline indices(hood::Stencil{<:Any,N}, I::NTuple{N}) where N = map(O -> map(+, O, I), offsets(hood))
+
 Base.@propagate_inbounds indexat(hood::Stencil, center, i) = CartesianIndex(offsets(hood)[i]) + center
 
 """

--- a/src/stencils/positional.jl
+++ b/src/stencils/positional.jl
@@ -30,7 +30,10 @@ Positional{((0, -1), (2, 1), (-1, 1), (0, 1)), 2, 2, 4, Nothing}
 """
 struct Positional{O,R,N,L,T} <: Stencil{R,N,L,T}
     neighbors::SVector{L,T}
-    Positional{O,R,N,L,T}(neighbors::SVector{L,T}) where {O,R,N,L,T} = new{O,R,N,L,T}(neighbors)
+    function Positional{O,R,N,L,T}(neighbors::SVector{L,T}) where {O,R,N,L,T} 
+        @assert all(map(o -> length(o) == N, O)) "All offsets must be the length `N` of $N, got $O" 
+        new{O,R,N,L,T}(neighbors)
+    end
 end
 Positional{O,R,N,L}(neighbors::SVector{L,T}) where {O,R,N,L,T} = 
     Positional{O,R,N,L,T}(neighbors)

--- a/test/array.jl
+++ b/test/array.jl
@@ -41,6 +41,14 @@ using Stencils, Test, LinearAlgebra, StaticArrays, OffsetArrays, Statistics
         @test all(==(0.0), B)
         @test all(==(0.0), C)
     end
+
+    @testset "1d Window on 2d match 2d line on 2d" begin
+        r = rand(100, 100)
+        A2d1d = StencilArray(copy(r), Window{1,1}(), padding=Conditional(), boundary=Remove(0.0));
+        A2dline = StencilArray(copy(r), Vertical{1,2}(), padding=Conditional(), boundary=Remove(0.0));
+        @test mapstencil(sum, A2dline) == mapstencil(sum, A2d1d)
+    end
+
     @testset "3d" begin
         r = rand(100, 100, 100)
         A = StencilArray(r, VonNeumann{10,3}(), padding=Conditional(), boundary=Remove(0.0));
@@ -55,6 +63,17 @@ using Stencils, Test, LinearAlgebra, StaticArrays, OffsetArrays, Statistics
         D .= 0.0
         axes(parent(D))
         @test all(==(0.0), D)
+    end
+
+    @testset "2d Window on 2d match 2d line on 2d" begin
+        r = rand(100, 100, 100)
+        window_2d = Window{1,2}()
+        pos_3d = Positional((-1, -1, 0), (0, -1, 0), (1, -1, 0), (-1, 0, 0), (0, 0, 0), (1, 0, 0), (-1, 1, 0), (0, 1, 0), (1, 1, 0))
+        @test indices(window_2d, (10, 10, 10)) == indices(pos_3d, (10, 10, 10))
+        A3d_window_2d = StencilArray(copy(r), window_2d, padding=Conditional(), boundary=Remove(0.0));
+        A3d_pos_3d = StencilArray(copy(r), pos_3d, padding=Conditional(), boundary=Remove(0.0));
+        @test neighbors(A3d_window_2d, (10, 10, 10)) == neighbors(A3d_pos_3d, (10, 10, 10))
+        @test mapstencil(sum, A3d_window_2d) == mapstencil(sum, A3d_pos_3d)
     end
 end
 


### PR DESCRIPTION
This PR allows stencils with `N` smaller than the array `N`.

My use case is to have independent layers along additional dimensions of an array, but apply the same stencil function to them all. This means that e.g. 100 replicate simulations can be run in the same GPU kernel call by adding a dimension to the array - but not changing the `Stencil`.