### PR TITLE
test that wrapper types propagate with a DimArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,6 +20,7 @@ Aqua = "0.8"
 BenchmarkTools = "1"
 ConstructionBase = "1"
 Dates = "0.1, 1"
+DimensionalData = "0.25"
 KernelAbstractions = "0.9"
 LinearAlgebra = "0.1, 1"
 Random = "1"
@@ -35,6 +36,7 @@ julia = "1.6"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -42,4 +44,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "SafeTestsets", "Statistics", "Test", "Unitful"]
+test = ["Aqua", "BenchmarkTools", "DimensionalData", "SafeTestsets", "Statistics", "Test", "Unitful"]

--- a/src/mapstencil.jl
+++ b/src/mapstencil.jl
@@ -18,9 +18,19 @@ function mapstencil(f, source::AbstractStencilArray{<:Any,<:Any,T,N}, args::Abst
     return mapstencil!(f, dest, source, args...)
 end
 function mapstencil(f, hood::StencilOrLayered, A::AbstractArray, args::AbstractArray...; kw...)
-    sa = StencilArray(A, Window(1))
+    sa = StencilArray(A, Window(1); kw...)
     T_return = _return_type(f, sa, args...)
-    return mapstencil!(f, similar(A, T_return), sa, args...)
+    dest = if padding(sa) isa Halo{:in}
+        # We need to shrink the dest array size
+        I = map(axes(A)) do ax
+            first(ax) + radius(hood):last(ax) - radius(hood)
+        end
+        # Take a view shrunk by the radius in case the array has specific axes
+        similar(view(A, I...), T_return)
+    else
+        similar(A, T_return)
+    end
+    return mapstencil!(f, dest, sa, args...)
 end
 
 function _return_type(f, A::AbstractStencilArray{<:Any,<:Any,T}, args...) where T

--- a/src/mapstencil.jl
+++ b/src/mapstencil.jl
@@ -13,18 +13,25 @@ The result is returned as a new array.
 """
 function mapstencil(f, source::AbstractStencilArray{<:Any,<:Any,T,N}, args::AbstractArray...) where {T,N}
     _checksizes((source, args...))
-    # Get the type of the stencil
-    bc = boundary(source)
-    T1 = bc isa Remove ? promote_type(T, typeof(padval(bc))) : T
-    emptyneighbors = _zero_values(T1, stencil(source))
-    H = typeof(rebuild(stencil(source), emptyneighbors))
-    # Use nasty broadcast mechanism `_return_type` to get the new eltype
-    T_return = Base._return_type(f, Tuple{H,map(eltype, args)...})
+    T_return = _return_type(f, source, args...)
     dest = similar(parent(source), T_return, size(source))
-    mapstencil!(f, dest, source, args...)
+    return mapstencil!(f, dest, source, args...)
 end
-mapstencil(f, hood::StencilOrLayered, A::AbstractArray, args::AbstractArray...; kw...) =
-    mapstencil(f, StencilArray(A, hood; kw...), args...)
+function mapstencil(f, hood::StencilOrLayered, A::AbstractArray, args::AbstractArray...; kw...)
+    sa = StencilArray(A, Window(1))
+    T_return = _return_type(f, sa, args...)
+    return mapstencil!(f, similar(A, T_return), sa, args...)
+end
+
+function _return_type(f, A::AbstractStencilArray{<:Any,<:Any,T}, args...) where T
+    st = stencil(A)
+    bc = boundary(A)
+    T1 = bc isa Remove ? promote_type(T, typeof(padval(bc))) : T
+    emptyneighbors = _zero_values(T1, st)
+    H = typeof(rebuild(st, emptyneighbors))
+    # Use nasty broadcast mechanism `_return_type` to get the new eltype
+    return Base._return_type(f, Tuple{H,map(eltype, args)...})
+end
 
 _zero_values(::Type{T}, ::Stencil{<:Any,<:Any,L}) where {T,L} = SVector{L,T}(ntuple(_ -> zero(T), L))
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -118,10 +118,16 @@ end
 
 
     @testset "Wrapper array types propagate" begin
-        A = DimArray(r, (X, Y))
-        res = mapstencil(sum, Window(1), A)
-        @test res isa DimArray
-        @test dims(A) === dims(res)
+        A = DimArray(r, (X(10:10:50), Y(1.0:6.0)))
+        res_cond = mapstencil(sum, Window(1), A)
+        @test res_cond isa DimArray
+        @test dims(A) === dims(res_cond)
+        res_out = mapstencil(sum, Window(1), A; padding=Halo{:out}())
+        @test res_out isa DimArray
+        @test dims(A) === dims(res_out)
+        res_in = mapstencil(sum, Window(1), A; padding=Halo{:in}())
+        @test res_in isa DimArray
+        @test map(d -> d[2:end-1], dims(A)) == dims(res_in)
     end
 end
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -1,4 +1,4 @@
-using Stencils, Test, LinearAlgebra, StaticArrays, Statistics
+using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
 
 @testset "StencilArray" begin
 
@@ -115,6 +115,14 @@ end
     parent(A)
     parent(B)
     parent(C)
+
+
+    @testset "Wrapper array types propagate" begin
+        A = DimArray(r, (X, Y))
+        res = mapstencil(sum, Window(1), A)
+        @test res isa DimArray
+        @test dims(A) === dims(res)
+    end
 end
 
 @testset "pad/unpad axes" begin
@@ -136,4 +144,3 @@ end
     S .= S2
     @test S == S2
 end
-


### PR DESCRIPTION
Make sure wrapper types survive through `mapstencil`, using a DimArray from DimensionalData.jl as a test case.