### PR TITLE
Implement Base.copy for StencilArray and SwitchingStencilArray

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -622,7 +622,6 @@ Base.parent(A::SwitchingStencilArray) = A.source
 
 Base.similar(src::SwitchingStencilArray{S}) where {S} =
     SwitchingStencilArray{S}(similar(source(src)),similar(dest(src)),stencil(src),boundary(src), padding(src))
-
 function Base.similar(src::SwitchingStencilArray{S}, ::Type{T}, dims::Tuple{Int,Vararg{Int}}) where {S,T}
     old_dims = size(src)
     halo_dims = size(parent(src)) .- old_dims
@@ -632,7 +631,7 @@ end
 
 Base.similar(src::SwitchingStencilArray{S,T}, dims::Tuple{Int,Vararg{Int}}) where {S,T} = similar(src, T, dims)
 Base.similar(src::SwitchingStencilArray{S}, ::Type{T}) where {S,T} = similar(src, T, size(src))
-    
+
 function Base.copy(src::SwitchingStencilArray)
     cp = similar(src)
     copyto!(source(cp), source(src))

--- a/src/array.jl
+++ b/src/array.jl
@@ -493,13 +493,13 @@ end
 _size(::Conditional, stencil, parent) = size(parent)
 _size(::Halo, ::Union{Stencil{R},Layered{R}}, parent) where R = size(parent) .- 2R
 
-"""Allocates similar array for StencilArray. Assumes that the stencil, boundary and padding are immutables."""
-function _similar(src::StencilArray{S,R}) where {S,R}
+#Allocates similar array for StencilArray. Assumes that the stencil, boundary and padding are immutables.
+function Base.similar(src::StencilArray{S,R}) where {S,R}
     return StencilArray{S,R}(similar(parent(src)),stencil(src),boundary(src), padding(src))
 end
 
 function Base.copy(src::StencilArray)
-    cp = _similar(src)
+    cp = similar(src)
     copyto!(parent(cp), parent(src)) #copy parent array to make sure that padding is also copied
     return cp
 end
@@ -611,11 +611,11 @@ switch(A::SwitchingStencilArray{S}) where S =
 
 Base.parent(A::SwitchingStencilArray) = A.source
 
-_similar(src::SwitchingStencilArray{S}) where {S} =
+Base.similar(src::SwitchingStencilArray{S}) where {S} =
     SwitchingStencilArray{S}(similar(source(src)),similar(dest(src)),stencil(src),boundary(src), padding(src))
 
 function Base.copy(src::SwitchingStencilArray)
-    cp = _similar(src)
+    cp = similar(src)
     copyto!(source(cp), source(src))
     copyto!(dest(cp), dest(src))
     return cp

--- a/src/array.jl
+++ b/src/array.jl
@@ -493,6 +493,17 @@ end
 _size(::Conditional, stencil, parent) = size(parent)
 _size(::Halo, ::Union{Stencil{R},Layered{R}}, parent) where R = size(parent) .- 2R
 
+"""Allocates similar array for StencilArray. Assumes that the stencil, boundary and padding are immutables."""
+function _similar(src::StencilArray{S,R}) where {S,R}
+    return StencilArray{S,R}(similar(parent(src)),stencil(src),boundary(src), padding(src))
+end
+
+function Base.copy(src::StencilArray)
+    cp = _similar(src)
+    copyto!(parent(cp), parent(src)) #copy parent array to make sure that padding is also copied
+    return cp
+end
+
 function Adapt.adapt_structure(to, A::StencilArray{S}) where S
     newparent = Adapt.adapt(to, parent(A))
     newstencil = Adapt.adapt(to, stencil(A))

--- a/src/array.jl
+++ b/src/array.jl
@@ -498,6 +498,17 @@ function Base.similar(src::StencilArray{S,R}) where {S,R}
     return StencilArray{S,R}(similar(parent(src)),stencil(src),boundary(src), padding(src))
 end
 
+function Base.similar(src::StencilArray{S,R},::Type{T},dims::Tuple{Int,Vararg{Int}}) where {S,R,T}
+    old_dims = size(src)
+    halo_dims = size(parent(src)) .- old_dims
+    new_dims = dims .+ halo_dims
+    # @info "" new_dims halo_dims dims size(similar(parent(src),T,new_dims))
+    return StencilArray{dims,R}(similar(parent(src),T,new_dims),stencil(src),boundary(src), padding(src))
+end
+
+Base.similar(src::StencilArray{S,R,T},dims::Tuple{Int,Vararg{Int}}) where {S,R,T} = similar(src, T, dims)
+Base.similar(src::StencilArray{S,R},::Type{T}) where {S,R,T} = similar(src, T, size(src))
+
 function Base.copy(src::StencilArray)
     cp = similar(src)
     copyto!(parent(cp), parent(src)) #copy parent array to make sure that padding is also copied

--- a/src/array.jl
+++ b/src/array.jl
@@ -497,7 +497,6 @@ _size(::Halo, ::Union{Stencil{R},Layered{R}}, parent) where R = size(parent) .- 
 function Base.similar(src::StencilArray{S,R}) where {S,R}
     return StencilArray{S,R}(similar(parent(src)), stencil(src), boundary(src), padding(src))
 end
-
 function Base.similar(src::StencilArray{S,R}, ::Type{T}, dims::Tuple{Int,Vararg{Int}}) where {S,R,T}
     old_dims = size(src)
     halo_dims = size(parent(src)) .- old_dims
@@ -505,7 +504,6 @@ function Base.similar(src::StencilArray{S,R}, ::Type{T}, dims::Tuple{Int,Vararg{
     # @info "" new_dims halo_dims dims size(similar(parent(src),T,new_dims))
     return StencilArray{dims,R}(similar(parent(src), T, new_dims), stencil(src), boundary(src), padding(src))
 end
-
 Base.similar(src::StencilArray{S,R,T}, dims::Tuple{Int,Vararg{Int}}) where {S,R,T} = similar(src, T, dims)
 Base.similar(src::StencilArray{S,R}, ::Type{T}) where {S,R,T} = similar(src, T, size(src))
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -623,6 +623,16 @@ Base.parent(A::SwitchingStencilArray) = A.source
 Base.similar(src::SwitchingStencilArray{S}) where {S} =
     SwitchingStencilArray{S}(similar(source(src)),similar(dest(src)),stencil(src),boundary(src), padding(src))
 
+function Base.similar(src::SwitchingStencilArray{S}, ::Type{T}, dims::Tuple{Int,Vararg{Int}}) where {S,T}
+    old_dims = size(src)
+    halo_dims = size(parent(src)) .- old_dims
+    new_dims = dims .+ halo_dims
+    return SwitchingStencilArray{dims}(similar(source(src), T, new_dims),similar(dest(src), T, new_dims),stencil(src), boundary(src), padding(src))
+end
+
+Base.similar(src::SwitchingStencilArray{S,T}, dims::Tuple{Int,Vararg{Int}}) where {S,T} = similar(src, T, dims)
+Base.similar(src::SwitchingStencilArray{S}, ::Type{T}) where {S,T} = similar(src, T, size(src))
+    
 function Base.copy(src::SwitchingStencilArray)
     cp = similar(src)
     copyto!(source(cp), source(src))

--- a/src/array.jl
+++ b/src/array.jl
@@ -611,6 +611,16 @@ switch(A::SwitchingStencilArray{S}) where S =
 
 Base.parent(A::SwitchingStencilArray) = A.source
 
+_similar(src::SwitchingStencilArray{S}) where {S} =
+    SwitchingStencilArray{S}(similar(source(src)),similar(dest(src)),stencil(src),boundary(src), padding(src))
+
+function Base.copy(src::SwitchingStencilArray)
+    cp = _similar(src)
+    copyto!(source(cp), source(src))
+    copyto!(dest(cp), dest(src))
+    return cp
+end
+
 function Adapt.adapt_structure(to, A::SwitchingStencilArray{S}) where S
     newsource = Adapt.adapt(to, A.source)
     newdest = Adapt.adapt(to, A.dest)

--- a/src/array.jl
+++ b/src/array.jl
@@ -495,19 +495,19 @@ _size(::Halo, ::Union{Stencil{R},Layered{R}}, parent) where R = size(parent) .- 
 
 #Allocates similar array for StencilArray. Assumes that the stencil, boundary and padding are immutables.
 function Base.similar(src::StencilArray{S,R}) where {S,R}
-    return StencilArray{S,R}(similar(parent(src)),stencil(src),boundary(src), padding(src))
+    return StencilArray{S,R}(similar(parent(src)), stencil(src), boundary(src), padding(src))
 end
 
-function Base.similar(src::StencilArray{S,R},::Type{T},dims::Tuple{Int,Vararg{Int}}) where {S,R,T}
+function Base.similar(src::StencilArray{S,R}, ::Type{T}, dims::Tuple{Int,Vararg{Int}}) where {S,R,T}
     old_dims = size(src)
     halo_dims = size(parent(src)) .- old_dims
     new_dims = dims .+ halo_dims
     # @info "" new_dims halo_dims dims size(similar(parent(src),T,new_dims))
-    return StencilArray{dims,R}(similar(parent(src),T,new_dims),stencil(src),boundary(src), padding(src))
+    return StencilArray{dims,R}(similar(parent(src), T, new_dims), stencil(src), boundary(src), padding(src))
 end
 
-Base.similar(src::StencilArray{S,R,T},dims::Tuple{Int,Vararg{Int}}) where {S,R,T} = similar(src, T, dims)
-Base.similar(src::StencilArray{S,R},::Type{T}) where {S,R,T} = similar(src, T, size(src))
+Base.similar(src::StencilArray{S,R,T}, dims::Tuple{Int,Vararg{Int}}) where {S,R,T} = similar(src, T, dims)
+Base.similar(src::StencilArray{S,R}, ::Type{T}) where {S,R,T} = similar(src, T, size(src))
 
 function Base.copy(src::StencilArray)
     cp = similar(src)

--- a/test/array.jl
+++ b/test/array.jl
@@ -21,13 +21,13 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         @test size(similar(S)) == (100,)
         @test size(similar(C,Int)) == (80,)
 
-        @test size(similar(B,40)) == (40,)
-        @test size(similar(S,40)) == (40,)
-        @test size(similar(S,Int,40)) == (40,)
-        @test size(parent(similar(B,Int,20))) == (40,)
+        @test size(similar(B, 40)) == (40,)
+        @test size(similar(S, 40)) == (40,)
+        @test size(similar(S, Int, 40)) == (40,)
+        @test size(parent(similar(B, Int, 20))) == (40,)
         
-        @test eltype(similar(S,Bool,20)) == Bool
-        @test eltype(similar(B,Int,20)) == Int
+        @test eltype(similar(S, Bool, 20)) == Bool
+        @test eltype(similar(B, Int, 20)) == Int
 
         D = StencilArray(r, Moore{10,1}(); padding=Halo{:in}(), boundary=Remove(0.0));
         D .= 0.0
@@ -53,9 +53,9 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         @test size(similar(B)) == size(B)
         @test size(similar(C)) == size(C)
         @test size(similar(S)) == size(S)
-        @test size(similar(A,40,40)) == (40,40)
-        @test size(similar(B,40,40)) == (40,40)
-        @test eltype(similar(B,Int,20,20)) == Int
+        @test size(similar(A, 40, 40)) == (40,40)
+        @test size(similar(B, 40, 40)) == (40,40)
+        @test eltype(similar(B, Int, 20, 20)) == Int
         A .= 0
         B .= 0
         C .= 0

--- a/test/array.jl
+++ b/test/array.jl
@@ -150,3 +150,9 @@ end
     S .= S2
     @test S == S2
 end
+
+@testset "copy" begin
+    S = StencilArray(ones(6, 7), Moore{1,2}(); padding=Halo{:out}(), boundary=Wrap());
+    Scopy = copy(S)
+    @test S == Scopy
+end

--- a/test/array.jl
+++ b/test/array.jl
@@ -28,9 +28,9 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         @test size(C) === (80, 80)
         @test size(parent(C)) === (100, 100)
         @test axes(parent(C)) === (Base.OneTo(1:100), Base.OneTo(1:100))
-        @test typeof(similar(A)) == Matrix{Float64}
-        @test typeof(similar(B)) == Matrix{Float64}
-        @test typeof(similar(C)) == Matrix{Float64}
+        @test typeof(similar(A)) == typeof(A)
+        @test typeof(similar(B)) == typeof(B)
+        @test typeof(similar(C)) == typeof(C)
         @test size(similar(A)) == size(A)
         @test size(similar(B)) == size(B)
         @test size(similar(C)) == size(C)

--- a/test/array.jl
+++ b/test/array.jl
@@ -7,6 +7,9 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         A = StencilArray(r, VonNeumann{3,1}(); padding=Conditional(), boundary=Remove(0.0));
         B = StencilArray(r, Window{10,1}(); padding=Halo{:out}(), boundary=Remove(0.0));
         C = StencilArray(r, Moore{10,1}(); padding=Halo{:in}(), boundary=Wrap());
+
+        S = SwitchingStencilArray(r, Window{10,1}(); padding=Halo{:out}(), boundary=Wrap());
+
         @test size(A) == size(parent(A)) == (100,)
         @test size(B) == (100,)
         @test size(parent(B)) == (120,)
@@ -15,11 +18,15 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         
         @test size(similar(A)) == (100,)
         @test size(similar(B)) == (100,)
+        @test size(similar(S)) == (100,)
         @test size(similar(C,Int)) == (80,)
 
         @test size(similar(B,40)) == (40,)
+        @test size(similar(S,40)) == (40,)
+        @test size(similar(S,Int,40)) == (40,)
         @test size(parent(similar(B,Int,20))) == (40,)
-
+        
+        @test eltype(similar(S,Bool,20)) == Bool
         @test eltype(similar(B,Int,20)) == Int
 
         D = StencilArray(r, Moore{10,1}(); padding=Halo{:in}(), boundary=Remove(0.0));
@@ -31,6 +38,7 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         A = StencilArray(copy(r), VonNeumann{10}(), padding=Conditional(), boundary=Remove(0.0));
         B = StencilArray(copy(r), Window{10}(), padding=Halo{:out}(), boundary=Remove(0.0));
         C = StencilArray(copy(r), Moore{10}(), padding=Halo{:in}(), boundary=Remove(0.0));
+        S = SwitchingStencilArray(r, Window{10}(); padding=Halo{:out}(), boundary=Wrap());
         @test size(A) == size(parent(A)) == (100, 100)
         @test size(B) == (100, 100)
         @test size(parent(B)) === (120, 120)
@@ -44,6 +52,7 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         @test size(similar(A)) == size(A)
         @test size(similar(B)) == size(B)
         @test size(similar(C)) == size(C)
+        @test size(similar(S)) == size(S)
         @test size(similar(A,40,40)) == (40,40)
         @test size(similar(B,40,40)) == (40,40)
         @test eltype(similar(B,Int,20,20)) == Int

--- a/test/array.jl
+++ b/test/array.jl
@@ -12,6 +12,16 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         @test size(parent(B)) == (120,)
         @test size(C) == (80,)
         @test size(parent(C)) == (100,)
+        
+        @test size(similar(A)) == (100,)
+        @test size(similar(B)) == (100,)
+        @test size(similar(C,Int)) == (80,)
+
+        @test size(similar(B,40)) == (40,)
+        @test size(parent(similar(B,Int,20))) == (40,)
+
+        @test eltype(similar(B,Int,20)) == Int
+
         D = StencilArray(r, Moore{10,1}(); padding=Halo{:in}(), boundary=Remove(0.0));
         D .= 0.0
         @test all(==(0.0), D)
@@ -34,6 +44,9 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         @test size(similar(A)) == size(A)
         @test size(similar(B)) == size(B)
         @test size(similar(C)) == size(C)
+        @test size(similar(A,40,40)) == (40,40)
+        @test size(similar(B,40,40)) == (40,40)
+        @test eltype(similar(B,Int,20,20)) == Int
         A .= 0
         B .= 0
         C .= 0
@@ -59,6 +72,8 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         @test size(parent(B)) == (120, 120, 120)
         @test size(C) == (80, 80, 80)
         @test size(parent(C)) == (100, 100, 100)
+        @test size(similar(B)) == size(B)
+        @test size(similar(B,(30,30,30))) == ((30,30,30))
         D = StencilArray(r, Moore{10,3}(); padding=Halo{:in}(), boundary=Wrap());
         D .= 0.0
         @test all(==(0.0), D)

--- a/test/array.jl
+++ b/test/array.jl
@@ -150,9 +150,18 @@ end
     S .= S2
     @test S == S2
 end
-
+##
 @testset "copy" begin
+    S = StencilArray(ones(6, 7), Moore{1,2}());
+    Scopy = copy(S)
+    @test S == Scopy
+
     S = StencilArray(ones(6, 7), Moore{1,2}(); padding=Halo{:out}(), boundary=Wrap());
     Scopy = copy(S)
     @test S == Scopy
+
+    S = SwitchingStencilArray(ones(6, 7), Moore{1,2}(); padding=Halo{:out}(), boundary=Wrap());
+    Scopy = copy(S)
+    @test S == Scopy
+    
 end


### PR DESCRIPTION
should resolve #42.
Note that I am assuming that only the underlying arrays are not `isbits` and nothing else needs to be explicitly copied. I assume there is no way to mutate stencils objects or the other fields, right?
 
I wanted to also implement `Base.similar` but that broke [some of the unit tests which assume similar to return a normal array. ](https://github.com/rafaqz/Stencils.jl/blob/85695aef4a690cc108e87c3ad4a339f12d6f27f5/test/array.jl#L31C1-L33C52)
Perhaps it is best to also change the tests and rename my new method `_similar` into `Base.similar`?
