### PR TITLE
bugfix and test switching arrays

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -144,13 +144,12 @@ end
 @inline bounded_index(A::AbstractStencilArray, I::Tuple) =
     bounded_index(A, boundary(A), padding(A), I)
 # Halo doesn't change the bounded_index
-@inline bounded_index(A::AbstractStencilArray, boundary, padding, I) = I
+@inline bounded_index(A::AbstractStencilArray, boundary, padding::Halo, I::Tuple) = I
 # We cant do much here - the caller needs a bounds check
-@inline bounded_index(A::AbstractStencilArray, boundary::Remove, padding::Conditional, I) =
-    I
+@inline bounded_index(A::AbstractStencilArray, boundary::Remove, padding::Conditional, I::Tuple) = I
 @inline function bounded_index(
-    A::AbstractStencilArray{S,R}, boundary::Reflect, padding, I
-) where {S,R}
+    A::AbstractStencilArray{S}, boundary::Reflect, padding::Conditional, I::Tuple
+) where S
     map(I, tuple_contents(S)) do i, s
         if i < 1
             2 - i
@@ -162,8 +161,8 @@ end
     end
 end
 @inline function bounded_index(
-    A::AbstractStencilArray{S,R}, boundary::Wrap, padding::Conditional, I
-) where {S,R}
+    A::AbstractStencilArray{S}, boundary::Wrap, padding::Conditional, I::Tuple
+) where S
     map(I, tuple_contents(S)) do i, s
         if i < 1
             i + s
@@ -184,6 +183,8 @@ end
     unsafe_getindex(A, pad, I...)
 end
 
+_sub_radius(I, R) = map(i -> i .- R, I)
+
 # update_boundary!
 # Reset or wrap boundary where required. This allows us to ignore
 # bounds checks on stencils and still use a wraparound grid.
@@ -192,9 +193,9 @@ update_boundary!(A::AbstractStencilArray) =
     update_boundary!(A, padding(A), boundary(A))
 # Conditional sets boundary conditions on the fly
 update_boundary!(A::AbstractStencilArray, ::Conditional, ::BoundaryCondition) = A
-update_boundary!(A::AbstractStencilArray, ::Halo, ::Use) = A
+update_boundary!(A::AbstractStencilArray{S,R}, ::Halo, ::Use) where {S,R} = A
 # Halo needs updating
-@generated function update_boundary!(A::AbstractStencilArray{S,R}, ::Halo, bc::Remove) where {S<:Tuple,R}
+@generated function update_boundary!(A::AbstractStencilArray{S,R}, ::Halo, bc::BoundaryCondition) where {S,R}
     expr = Expr(:block)
     i = 1
     for _ in S.parameters
@@ -209,203 +210,25 @@ update_boundary!(A::AbstractStencilArray, ::Halo, ::Use) = A
                 push!(inds_expr2.args, :(Base.OneTo($P+2R)))
             end
         end
-        push!(expr.args, :(src[$inds_expr1...] .= (padval(bc),)))
-        push!(expr.args, :(src[$inds_expr2...] .= (padval(bc),)))
+        push!(expr.args, :(Isrc1 = $inds_expr1))
+        push!(expr.args, :(Isrc2 = $inds_expr2))
+        push!(expr.args, :(I1 = _sub_radius(Isrc1, R)))
+        push!(expr.args, :(I2 = _sub_radius(Isrc2, R)))
+        push!(expr.args, :(src[Isrc1...] .= halo_val.((A,), (bc,), CartesianIndices(I1))))
+        push!(expr.args, :(src[Isrc2...] .= halo_val.((A,), (bc,), CartesianIndices(I2))))
         i += 1
     end
     return quote
         src = parent(A)
         $expr
+        return after_update_boundary!(A)
     end
 end
-function update_boundary!(A::AbstractStencilArray{S,R}, ::Halo, ::Wrap) where {S<:Tuple{L},R} where {L}
-    src = parent(A)
-    startpad = 1:R
-    endpad = L+R+1:L+2R
-    startvals = R+1:2R
-    endvals = L+1:L+R
-    @assert length(startpad) == length(endvals) == R
-    @assert length(endpad) == length(startvals) == R
-    @inbounds src[startpad] .= src[endvals]
-    @inbounds src[endpad] .= src[startvals]
-    return A
-end
-function update_boundary!(A::AbstractStencilArray{S,R}, ::Halo, ::Wrap) where {S<:Tuple{Y,X},R} where {Y,X}
-    src = parent(A)
-    n_xs, n_ys = X, Y
-    startpad_x = startpad_y = 1:R
-    endpad_x = n_xs+R+1:n_xs+2R
-    endpad_y = n_ys+R+1:n_ys+2R
-    start_x = start_y = R+1:2R
-    end_x = n_xs+1:n_xs+R
-    end_y = n_ys+1:n_ys+R
-    xs = 1:n_xs+2R
-    ys = 1:n_ys+2R
 
-    @assert length(startpad_x) == length(start_x) == R
-    @assert length(endpad_x) == length(end_x) == R
-    @assert length(startpad_y) == length(start_y) == R
-    @assert length(endpad_y) == length(end_y) == R
-    @assert map(length, (ys, xs)) === size(src)
-
-    CI = CartesianIndices
-    # Sides ---
-    @inbounds src[CI((ys, startpad_x))] .= src[CI((ys, end_x))]
-    @inbounds src[CI((ys, endpad_x))]   .= src[CI((ys, start_x))]
-    @inbounds src[CI((startpad_y, xs))] .= src[CI((end_y, xs))]
-    @inbounds src[CI((endpad_y, xs))]   .= src[CI((start_y, xs))]
-
-    # Corners ---
-    @inbounds src[CI((startpad_y, startpad_x))] .= src[CI((end_y, end_x))]
-    @inbounds src[CI((startpad_y, endpad_x))]   .= src[CI((end_y, start_x))]
-    @inbounds src[CI((endpad_y, startpad_x))]   .= src[CI((start_y, end_x))]
-    @inbounds src[CI((endpad_y, endpad_x))]     .= src[CI((start_y, start_x))]
-
-    return after_update_boundary!(A)
-end
-# TODO: check line 265
-function update_boundary!(A::AbstractStencilArray{S,R}, ::Halo, ::Wrap) where {S<:Tuple{Z,Y,X},R} where {Z,Y,X}
-    src = parent(A)
-    n_xs, n_ys, n_zs = X, Y, Z
-    startpad_x = startpad_y = startpad_z = 1:R
-    endpad_x = n_xs+R+1:n_xs+2R
-    endpad_y = n_ys+R+1:n_ys+2R
-    endpad_z = n_ys+R+1:n_zs+2R
-    start_x = start_y = start_z = R+1:2R
-    end_x = n_xs+1:n_xs+R
-    end_y = n_ys+1:n_ys+R
-    end_z = n_zs+1:n_zs+R
-    xs = 1:n_xs+2R
-    ys = 1:n_ys+2R
-    zs = 1:n_zs+2R
-
-    @assert length(startpad_x) == length(start_x) == R
-    @assert length(endpad_x) == length(end_x) == R
-    @assert length(startpad_y) == length(start_y) == R
-    @assert length(endpad_y) == length(end_y) == R
-    @assert map(length, (zs , ys, xs)) === size(src)
-
-    CI = CartesianIndices
-    # Sides ---
-    # X
-    @inbounds copyto!(src, CI((startpad_y, xs, zs)), src, CI((end_y, xs, zs)))
-    @inbounds copyto!(src, CI((endpad_y, xs, zs)), src, CI((start_y, xs, zs)))
-    # Y
-    @inbounds copyto!(src, CI((ys, startpad_x, zs)), src, CI((ys, end_x, zs)))
-    @inbounds copyto!(src, CI((ys, endpad_x, zs)), src, CI((ys, start_x, zs)))
-    # Z
-    @inbounds copyto!(src, CI((ys, xs, startpad_z)), src, CI((ys, xs, end_z)))
-    @inbounds copyto!(src, CI((ys, xs, endpad_z)), src, CI((ys, xs, start_z)))
-
-    # Corners ---
-    @inbounds src[CI((startpad_y, startpad_x, startpad_z))] .= src[CI((end_y, end_x, end_z))]
-    @inbounds src[CI((startpad_y, startpad_x, endpad_z))] .= src[CI((end_y, end_x, start_z))]
-    @inbounds src[CI((startpad_y, endpad_x, startpad_z))] .= src[CI((end_y, start_x, end_z))]
-    @inbounds src[CI((startpad_y, endpad_x, endpad_x))] .= src[CI((end_y, start_x, start_z))]
-    @inbounds src[CI((endpad_y, endpad_x, endpad_z))] .= src[CI((start_y, start_x, start_z))]
-    @inbounds src[CI((endpad_y, startpad_x, endpad_z))] .= src[CI((end_y, start_x, start_z))] # TODO: check
-    @inbounds src[CI((endpad_y, endpad_x, startpad_z))] .= src[CI((start_y, start_x, end_z))]
-    @inbounds src[CI((endpad_y, startpad_x, startpad_z))] .= src[CI((start_y, end_x, end_z))]
-    return after_update_boundary!(A)
-end
-
-# Reflect() boundary conditions for update_boundary!
-# One dimension
-function update_boundary!(A::AbstractStencilArray{S,R}, ::Halo, ::Reflect) where {S<:Tuple{L},R} where {L}
-    src = parent(A)
-    startpad = 1:R
-    endpad = L+R+1:L+2R
-    startvals = R+1:2R
-    endvals = L+1:L+R
-
-    @assert length(startpad) == length(endvals) == R
-    @assert length(endpad) == length(startvals) == R
-
-    # Reflect values at the boundaries
-    @inbounds src[startpad] .= src[reverse(startvals)]
-    @inbounds src[endpad] .= src[reverse(endvals)]
-
-    return A
-end
-
-# Two dimensions
-function update_boundary!(A::AbstractStencilArray{S,R}, ::Halo, ::Reflect) where {S<:Tuple{Y,X},R} where {Y,X}
-    src = parent(A)
-    n_xs, n_ys = X, Y
-    startpad_x = startpad_y = 1:R
-    endpad_x = n_xs+R+1:n_xs+2R
-    endpad_y = n_ys+R+1:n_ys+2R
-    start_x = start_y = R+1:2R
-    end_x = n_xs+1:n_xs+R
-    end_y = n_ys+1:n_ys+R
-    xs = 1:n_xs+2R
-    ys = 1:n_ys+2R
-
-    @assert length(startpad_x) == length(start_x) == R
-    @assert length(endpad_x) == length(end_x) == R
-    @assert length(startpad_y) == length(start_y) == R
-    @assert length(endpad_y) == length(end_y) == R
-    @assert map(length, (ys, xs)) === size(src)
-
-    CI = CartesianIndices
-    # Sides ---
-    @inbounds src[CI((ys, startpad_x))] .= src[CI((ys, start_x))]
-    @inbounds src[CI((ys, endpad_x))]   .= src[CI((ys, end_x))]
-    @inbounds src[CI((startpad_y, xs))] .= src[CI((start_y, xs))]
-    @inbounds src[CI((endpad_y, xs))]   .= src[CI((end_y, xs))]
-
-    # Corners ---
-    @inbounds src[CI((startpad_y, startpad_x))] .= src[CI((start_y, start_x))]
-    @inbounds src[CI((startpad_y, endpad_x))]   .= src[CI((start_y, end_x))]
-    @inbounds src[CI((endpad_y, startpad_x))]   .= src[CI((end_y, start_x))]
-    @inbounds src[CI((endpad_y, endpad_x))]     .= src[CI((end_y, end_x))]
-    return after_update_boundary!(A)
-end
-
-# Three dimensions
-function update_boundary!(A::AbstractStencilArray{S,R}, ::Halo, ::Reflect) where {S<:Tuple{Z,Y,X},R} where {Z,Y,X}
-    src = parent(A)
-    n_xs, n_ys, n_zs = X, Y, Z
-    startpad_x = startpad_y = startpad_z = 1:R
-    endpad_x = n_xs + R + 1:n_xs + 2R
-    endpad_y = n_ys + R + 1:n_ys + 2R
-    endpad_z = n_ys + R + 1:n_zs + 2R
-    start_x = start_y = start_z = R + 1:2R
-    end_x = n_xs + 1:n_xs + R
-    end_y = n_ys + 1:n_ys + R
-    end_z = n_zs + 1:n_zs + R
-    xs = 1:n_xs + 2R
-    ys = 1:n_ys + 2R
-    zs = 1:n_zs + 2R
-
-    @assert length(startpad_x) == length(start_x) == R
-    @assert length(endpad_x) == length(end_x) == R
-    @assert length(startpad_y) == length(start_y) == R
-    @assert length(endpad_y) == length(end_y) == R
-    @assert map(length, (zs, ys, xs)) === size(src)
-
-    CI = CartesianIndices
-    # Sides ---
-    # X
-    @inbounds copyto!(src, CI((startpad_y, xs, zs)), src, CI((end_y, xs, zs)))
-    @inbounds copyto!(src, CI((endpad_y, xs, zs)), src, CI((start_y, xs, zs)))
-    # Y
-    @inbounds copyto!(src, CI((ys, startpad_x, zs)), src, CI((ys, end_x, zs)))
-    @inbounds copyto!(src, CI((ys, endpad_x, zs)), src, CI((ys, start_x, zs)))
-    # Z
-    @inbounds copyto!(src, CI((ys, xs, startpad_z)), src, CI((ys, xs, end_z)))
-    @inbounds copyto!(src, CI((ys, xs, endpad_z)), src, CI((ys, xs, start_z)))
-
-    # Corners ---
-    @inbounds src[CI((startpad_y, startpad_x, startpad_z))] .= src[CI((start_y, start_x, start_z))]
-    @inbounds src[CI((startpad_y, startpad_x, endpad_z))] .= src[CI((start_y, start_x, end_z))]
-    @inbounds src[CI((startpad_y, endpad_x, startpad_z))] .= src[CI((start_y, end_x, start_z))]
-    @inbounds src[CI((startpad_y, endpad_x, endpad_z))] .= src[CI((start_y, end_x, end_z))]
-    @inbounds src[CI((endpad_y, endpad_x, endpad_z))] .= src[CI((end_y, end_x, end_z))]
-    @inbounds src[CI((endpad_y, startpad_x, endpad_z))] .= src[CI((end_y, end_x, end_z))]
-    @inbounds src[CI((endpad_y, endpad_x, startpad_z))] .= src[CI((end_y, end_x, start_z))]
-    @inbounds src[CI((endpad_y, startpad_x, startpad_z))] .= src[CI((end_y, start_x, start_z))]
-    return after_update_boundary!(A)
+@inline halo_val(A, bc::Remove, I::CartesianIndex) = padval(bc)
+@inline halo_val(A, bc::Union{Wrap,Reflect}, I::CartesianIndex) = begin
+    bI = bounded_index(A, bc, Conditional(), Tuple(I))
+    return A[bI...]
 end
 
 # Allow additional boundary updating behaviours
@@ -479,13 +302,18 @@ function Base.copyto!(dst::AbstractStencilArray, src::AbstractArray)
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", A::AbstractStencilArray)
-    show(io, mime, Array(A))
-    println()
-    println()
+    summary(io, A)
+    isempty(A) && return
+    print(io, ":")
+    Base.show_circular(io, A) && return
+
+    println(io)
+    Base.print_matrix(io, collect(A))
+    print(io, "\n\nstencil: ")
     show(io, mime, stencil(A))
-    println()
+    print(io, "boundary: ")
     show(io, mime, boundary(A))
-    println()
+    print(io, "\npadding: ")
     show(io, mime, padding(A))
 end
 
@@ -635,18 +463,10 @@ _size(::Conditional, stencil, parent) = size(parent)
 _size(::Halo, ::Union{Stencil{R},Layered{R}}, parent) where R = size(parent) .- 2R
 
 #Allocates similar array for StencilArray. Assumes that the stencil, boundary and padding are immutables.
-function Base.similar(src::StencilArray{S,R}) where {S,R}
-    return StencilArray{S,R}(similar(parent(src)), stencil(src), boundary(src), padding(src))
-end
-function Base.similar(src::StencilArray{S,R}, ::Type{T}, dims::Tuple{Int,Vararg{Int}}) where {S,R,T}
-    old_dims = size(src)
-    halo_dims = size(parent(src)) .- old_dims
-    new_dims = dims .+ halo_dims
-    # @info "" new_dims halo_dims dims size(similar(parent(src),T,new_dims))
-    return StencilArray{dims,R}(similar(parent(src), T, new_dims), stencil(src), boundary(src), padding(src))
-end
-Base.similar(src::StencilArray{S,R,T}, dims::Tuple{Int,Vararg{Int}}) where {S,R,T} = similar(src, T, dims)
-Base.similar(src::StencilArray{S,R}, ::Type{T}) where {S,R,T} = similar(src, T, size(src))
+Base.similar(A::StencilArray{S}) where {S} =
+    StencilArray{S}(similar(parent(A)), stencil(A), boundary(A), padding(A))
+Base.similar(A::StencilArray{S}, ::Type{T}) where {S,T} =
+    StencilArray{S}(similar(parent(A), T), stencil(A), boundary(A), padding(A))
 
 function Base.copy(src::StencilArray)
     cp = similar(src)
@@ -674,10 +494,13 @@ abstract type AbstractSwitchingStencilArray{S,R,T,N,A,H,BC,P} <: AbstractStencil
 Base.parent(d::AbstractSwitchingStencilArray) = source(d)
 
 source(A::AbstractSwitchingStencilArray) = A.source
+source(A::AbstractStencilArray) = parent(A)
+
 dest(A::AbstractSwitchingStencilArray) = A.dest
+dest(A::AbstractStencilArray) = parent(A)
+
 radius(d::AbstractStencilArray{<:Any,R}) where R = R
 padval(d::AbstractStencilArray) = padval(boundary(d))
-
 
 """
     SwitchingStencilArray <: AbstractSwitchingStencilArray
@@ -742,6 +565,7 @@ end
 function SwitchingStencilArray(parent::AbstractArray, hood::StencilOrLayered, bc, padding)
     padded_source = pad_array(padding, bc, hood, parent)
     padded_dest = pad_array(padding, bc, hood, parent)
+    padded_dest = padded_source === padded_dest ? copy(padded_source) : padded_dest
     S = Tuple{_size(padding, hood, padded_source)...}
     return SwitchingStencilArray{S}(padded_source, padded_dest, hood, bc, padding)
 end
@@ -759,19 +583,12 @@ Swap the source and dest of a `SwitchingStencilArray`.
 switch(A::SwitchingStencilArray{S}) where S =
     SwitchingStencilArray{S}(dest(A), source(A), stencil(A), boundary(A), padding(A))
 
-Base.parent(A::SwitchingStencilArray) = A.source
+Base.parent(A::SwitchingStencilArray) = source(A)
 
 Base.similar(src::SwitchingStencilArray{S}) where {S} =
-    SwitchingStencilArray{S}(similar(source(src)),similar(dest(src)),stencil(src),boundary(src), padding(src))
-function Base.similar(src::SwitchingStencilArray{S}, ::Type{T}, dims::Tuple{Int,Vararg{Int}}) where {S,T}
-    old_dims = size(src)
-    halo_dims = size(parent(src)) .- old_dims
-    new_dims = dims .+ halo_dims
-    return SwitchingStencilArray{dims}(similar(source(src), T, new_dims),similar(dest(src), T, new_dims),stencil(src), boundary(src), padding(src))
-end
-
-Base.similar(src::SwitchingStencilArray{S,T}, dims::Tuple{Int,Vararg{Int}}) where {S,T} = similar(src, T, dims)
-Base.similar(src::SwitchingStencilArray{S}, ::Type{T}) where {S,T} = similar(src, T, size(src))
+    SwitchingStencilArray{S}(similar(source(src)), similar(dest(src)), stencil(src), boundary(src), padding(src))
+Base.similar(src::SwitchingStencilArray{S}, ::Type{T}) where {S,T} =
+    SwitchingStencilArray{S}(similar(source(src), T), similar(dest(src), T), stencil(src), boundary(src), padding(src))
 
 function Base.copy(src::SwitchingStencilArray)
     cp = similar(src)

--- a/src/array.jl
+++ b/src/array.jl
@@ -308,7 +308,7 @@ function Base.show(io::IO, mime::MIME"text/plain", A::AbstractStencilArray)
     Base.show_circular(io, A) && return
 
     println(io)
-    Base.print_matrix(io, collect(A))
+    Base.print_array(io, A)
     print(io, "\n\nstencil: ")
     show(io, mime, stencil(A))
     print(io, "boundary: ")

--- a/src/mapstencil.jl
+++ b/src/mapstencil.jl
@@ -62,11 +62,15 @@ returning a switched version of the array.
 sides, or be the same size, in which case it is assumed to also be padded.
 """
 function mapstencil!(f, A::SwitchingStencilArray, args::AbstractArray...)
-    mapstencil!(f, dest(A), A, args...)
+    pd = padding(A) isa Halo ? Halo{:in}() : padding(A)
+    src = StencilArray(source(A), stencil(A), boundary(A), pd)
+    dst = StencilArray(dest(A), stencil(A), boundary(A), pd)
+    mapstencil!(f, dst, src, args...)
     return switch(A)
 end
 function mapstencil!(f, A::SwitchingStencilArray, B::AbstractStencilArray, args::AbstractArray...)
-    mapstencil!(f, dest(A), A, B, args...)
+    dst = StencilArray(dest(A), stencil(A), boundary(A), padding(A))
+    mapstencil!(f, dst, A, B, args...)
     return switch(A)
 end
 function mapstencil!(

--- a/test/array.jl
+++ b/test/array.jl
@@ -259,6 +259,7 @@ end
     end
 
     @testset "Wrapper array types propagate" begin
+        r = (1.0:5.0) * (100.0:105.0)'
         A = DimArray(r, (X(10:10:50), Y(1.0:6.0)))
         res_cond = mapstencil(sum, Window(1), A)
         @test res_cond isa DimArray

--- a/test/array.jl
+++ b/test/array.jl
@@ -20,6 +20,7 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         SA = SwitchingStencilArray(r, Window{10,1}(); padding=Conditional(), boundary=Remove(0.0));
         SB = SwitchingStencilArray(r, Window{10,1}(); padding=Halo{:out}(), boundary=Remove(0.0));
         SC = SwitchingStencilArray(r, Window{10,1}(); padding=Halo{:in}(), boundary=Remove(0.0));
+
         @test SA.source !== SA.dest
 
         @test size(A) == size(parent(A)) == size(SA) == size(parent(SA)) == (100,)
@@ -34,9 +35,6 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
 
         @test size(similar(B, 40)) == size(similar(SB, 40)) == (40,)
         @test eltype(similar(B, Int)) == eltype(similar(SB, Int)) == Int
-        
-        @test eltype(similar(S, Bool, 20)) == Bool
-        @test eltype(similar(B, Int, 20)) == Int
 
         D = StencilArray(r, Moore{10,1}(); padding=Halo{:in}(), boundary=Remove(0.0));
         D .= 0.0
@@ -51,6 +49,7 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         SA = SwitchingStencilArray(copy(r), VonNeumann{10}(), padding=Conditional(), boundary=Remove(0.0));
         SB = SwitchingStencilArray(copy(r), Window{10}(), padding=Halo{:out}(), boundary=Remove(0.0));
         SC = SwitchingStencilArray(copy(r), Moore{10}(), padding=Halo{:in}(), boundary=Remove(0.0));
+
         @test size(A) == size(SA) == size(parent(A)) == (100, 100)
         @test size(B) == size(SB) == (100, 100)
         @test size(parent(B)) === size(parent(SB)) === (120, 120)
@@ -90,6 +89,10 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         A = StencilArray(r, VonNeumann{10,3}(), padding=Conditional(), boundary=Remove(0.0));
         B = StencilArray(r, Window{10,3}(), padding=Halo{:out}(), boundary=Remove(0.0));
         C = StencilArray(r, Moore{10,3}(), padding=Halo{:in}(), boundary=Remove(0.0));
+        SA = SwitchingStencilArray(r, VonNeumann{10,3}(), padding=Conditional(), boundary=Remove(0.0));
+        SB = SwitchingStencilArray(r, Window{10,3}(), padding=Halo{:out}(), boundary=Remove(0.0));
+        SC = SwitchingStencilArray(r, Moore{10,3}(), padding=Halo{:in}(), boundary=Remove(0.0));
+
         @test size(A) == size(parent(A)) == (100, 100, 100)
         @test size(B) == (100, 100, 100)
         @test size(parent(B)) == (120, 120, 120)

--- a/test/array.jl
+++ b/test/array.jl
@@ -8,31 +8,32 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         @test indices(A, (1, 1)) == [(4, 4), (1, 4), (2, 4), (4, 1), (2, 1), (4, 2), (1, 2), (2, 2)]
         A = StencilArray(zeros(4, 4), Moore(), boundary=Reflect(), padding=Conditional())
         @test indices(A, (1, 1)) == [(2, 2), (1, 2), (2, 2), (2, 1), (2, 1), (2, 2), (1, 2), (2, 2)]
+        S = SwitchingStencilArray(zeros(4, 4), Moore(), boundary=Reflect(), padding=Conditional())
+        @test indices(S, (1, 1)) == [(2, 2), (1, 2), (2, 2), (2, 1), (2, 1), (2, 2), (1, 2), (2, 2)]
     end
 
     @testset "1d" begin
         r = rand(100)
         A = StencilArray(r, VonNeumann{3,1}(); padding=Conditional(), boundary=Remove(0.0));
         B = StencilArray(r, Window{10,1}(); padding=Halo{:out}(), boundary=Remove(0.0));
-        C = StencilArray(r, Moore{10,1}(); padding=Halo{:in}(), boundary=Wrap());
+        C = StencilArray(r, Moore{10,1}(); padding=Halo{:in}(), boundary=Remove(0.0));
+        SA = SwitchingStencilArray(r, Window{10,1}(); padding=Conditional(), boundary=Remove(0.0));
+        SB = SwitchingStencilArray(r, Window{10,1}(); padding=Halo{:out}(), boundary=Remove(0.0));
+        SC = SwitchingStencilArray(r, Window{10,1}(); padding=Halo{:in}(), boundary=Remove(0.0));
+        @test SA.source !== SA.dest
 
-        S = SwitchingStencilArray(r, Window{10,1}(); padding=Halo{:out}(), boundary=Wrap());
-
-        @test size(A) == size(parent(A)) == (100,)
-        @test size(B) == (100,)
-        @test size(parent(B)) == (120,)
-        @test size(C) == (80,)
-        @test size(parent(C)) == (100,)
+        @test size(A) == size(parent(A)) == size(SA) == size(parent(SA)) == (100,)
+        @test size(B) == size(SB) == (100,)
+        @test size(parent(B)) == size(parent(SB)) == (120,)
+        @test size(C) == size(SC) == (80,)
+        @test size(parent(C)) == size(parent(SC)) == (100,)
         
-        @test size(similar(A)) == (100,)
-        @test size(similar(B)) == (100,)
-        @test size(similar(S)) == (100,)
-        @test size(similar(C,Int)) == (80,)
+        @test size(similar(A)) == size(similar(SA)) == (100,)
+        @test size(similar(B)) == size(similar(SB)) == (100,)
+        @test size(similar(C)) == size(similar(SC)) == (80,)
 
-        @test size(similar(B, 40)) == (40,)
-        @test size(similar(S, 40)) == (40,)
-        @test size(similar(S, Int, 40)) == (40,)
-        @test size(parent(similar(B, Int, 20))) == (40,)
+        @test size(similar(B, 40)) == size(similar(SB, 40)) == (40,)
+        @test eltype(similar(B, Int)) == eltype(similar(SB, Int)) == Int
         
         @test eltype(similar(S, Bool, 20)) == Bool
         @test eltype(similar(B, Int, 20)) == Int
@@ -41,26 +42,31 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         D .= 0.0
         @test all(==(0.0), D)
     end
+
     @testset "2d" begin
         r = rand(100, 100)
         A = StencilArray(copy(r), VonNeumann{10}(), padding=Conditional(), boundary=Remove(0.0));
         B = StencilArray(copy(r), Window{10}(), padding=Halo{:out}(), boundary=Remove(0.0));
         C = StencilArray(copy(r), Moore{10}(), padding=Halo{:in}(), boundary=Remove(0.0));
-        S = SwitchingStencilArray(r, Window{10}(); padding=Halo{:out}(), boundary=Wrap());
-        @test size(A) == size(parent(A)) == (100, 100)
-        @test size(B) == (100, 100)
-        @test size(parent(B)) === (120, 120)
-        @test axes(parent(B)) === (Base.OneTo(120), Base.OneTo(1:120))
-        @test size(C) === (80, 80)
-        @test size(parent(C)) === (100, 100)
-        @test axes(parent(C)) === (Base.OneTo(1:100), Base.OneTo(1:100))
+        SA = SwitchingStencilArray(copy(r), VonNeumann{10}(), padding=Conditional(), boundary=Remove(0.0));
+        SB = SwitchingStencilArray(copy(r), Window{10}(), padding=Halo{:out}(), boundary=Remove(0.0));
+        SC = SwitchingStencilArray(copy(r), Moore{10}(), padding=Halo{:in}(), boundary=Remove(0.0));
+        @test size(A) == size(SA) == size(parent(A)) == (100, 100)
+        @test size(B) == size(SB) == (100, 100)
+        @test size(parent(B)) === size(parent(SB)) === (120, 120)
+        @test axes(parent(B)) === axes(parent(SB)) === (Base.OneTo(120), Base.OneTo(1:120))
+        @test size(C) === size(SC) === (80, 80)
+        @test size(parent(C)) === size(parent(SC)) === (100, 100)
+        @test axes(parent(C)) === axes(parent(SC)) === (Base.OneTo(1:100), Base.OneTo(1:100))
         @test typeof(similar(A)) == typeof(A)
         @test typeof(similar(B)) == typeof(B)
         @test typeof(similar(C)) == typeof(C)
-        @test size(similar(A)) == size(A)
-        @test size(similar(B)) == size(B)
-        @test size(similar(C)) == size(C)
-        @test size(similar(S)) == size(S)
+        @test typeof(similar(SA)) == typeof(SA)
+        @test typeof(similar(SB)) == typeof(SB)
+        @test typeof(similar(SC)) == typeof(SC)
+        @test size(similar(A)) == size(similar(SA)) == size(A)
+        @test size(similar(B)) == size(similar(SB)) == size(B)
+        @test size(similar(C)) == size(similar(SC)) == size(C)
         @test size(similar(A, 40, 40)) == (40,40)
         @test size(similar(B, 40, 40)) == (40,40)
         @test eltype(similar(B, Int, 20, 20)) == Int
@@ -96,7 +102,7 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
         @test all(==(0.0), D)
     end
 
-    @testset "2d Window on 2d match 2d line on 2d" begin
+    @testset "2d Window matches 3d line on 3d" begin
         r = rand(100, 100, 100)
         window_2d = Window{1,2}()
         pos_3d = Positional((-1, -1, 0), (0, -1, 0), (1, -1, 0), (-1, 0, 0), (0, 0, 0), (1, 0, 0), (-1, 1, 0), (0, 1, 0), (1, 1, 0))
@@ -110,61 +116,144 @@ using Stencils, Test, LinearAlgebra, StaticArrays, Statistics, DimensionalData
 end
 
 @testset "mapstencil" begin
-    # Remove / Use
-    r = (1.0:5.0) * (100.0:105.0)'
-    A = StencilArray(r, Window{1,2}(); padding=Conditional(), boundary=Remove(zero(eltype(r))));
-    B = StencilArray(r, Window{1,2}(); padding=Halo{:out}(), boundary=Remove(zero(eltype(r))));
-    C = StencilArray(copy(r), Window{1,2}(); padding=Halo{:in}(), boundary=Stencils.Use())
-    @time A1 = mapstencil(mean, A)
-    @time B1 = mapstencil(mean, B)
-    @time C1 = mapstencil(mean, C)
-    @test A1 == B1
-    # `mean` just cancels out to give the same answer, inside the padding at least
-    @test A1[2:end-1, 2:end-1] == B1[2:end-1, 2:end-1] == C1 == r[2:end-1, 2:end-1]
-    @time A1 = mapstencil(sum, A)
-    @time B1 = mapstencil(sum, B)
-    @time C1 = mapstencil(sum, C)
-    @test A1 == B1
-    # `sum` gives a different array
-    @test A1[2:end-1, 2:end-1] == B1[2:end-1, 2:end-1] == C1 == [
-        1818.0  1836.0  1854.0  1872.0
-        2727.0  2754.0  2781.0  2808.0
-        3636.0  3672.0  3708.0  3744.0
-    ]
+    @testset "Remove / Use" begin
+        r = (1.0:5.0) * (100.0:105.0)'
+        A = StencilArray(r, Window{1,2}(); padding=Conditional(), boundary=Remove(zero(eltype(r))));
+        B = StencilArray(r, Window{1,2}(); padding=Halo{:out}(), boundary=Remove(zero(eltype(r))));
+        C = StencilArray(copy(r), Window{1,2}(); padding=Halo{:in}(), boundary=Stencils.Use())
+        SA = SwitchingStencilArray(copy(r), Window{1,2}(); padding=Conditional(), boundary=Remove(zero(eltype(r))));
+        SB = SwitchingStencilArray(copy(r), Window{1,2}(); padding=Halo{:out}(), boundary=Remove(zero(eltype(r))));
+        SC = SwitchingStencilArray(copy(r), Window{1,2}(); padding=Halo{:in}(), boundary=Stencils.Use());
 
-    # Wrap
-    r = (1.0:5.0) * (100.0:105.0)'
-    A = StencilArray(r, Moore{1,2}(); padding=Conditional(), boundary=Wrap());
-    B = StencilArray(r, Moore{1,2}(); padding=Halo{:out}(), boundary=Wrap());
-    C = StencilArray(copy(r), Moore{1,2}(); padding=Halo{:in}(), boundary=Wrap());
-    @time A1 = mapstencil(mean, A)
-    @time B1 = mapstencil(mean, B)
-    @time C1 = mapstencil(mean, C)
-    @test A1[3:end-2, 3:end-2] == B1[3:end-2, 3:end-2] == C1[2:end-1, 2:end-1]
-    # But C is smaller so the outer wring is different
-    # from wrapping in a different place
-    @test A1 == B1
-    @test A1[2:end-1, 2:end-1] != C1
-    parent(A)
-    parent(B)
-    parent(C)
+        # `mean` just cancels out to give the same answer, inside the padding at least
+        @time A1 = mapstencil(mean, A)
+        @time B1 = mapstencil(mean, B)
+        @time C1 = mapstencil(mean, C)
+        @time SA1 = mapstencil!(mean, SA)
+        @time SB1 = mapstencil!(mean, SB)
+        @time SC1 = mapstencil!(mean, SC)
+        @test A1 == B1 == SA1 == SB1 ≈ [
+             67.0 101.0 102.0 103.0 104.0  69.66666666667
+            134.0 202.0 204.0 206.0 208.0 139.33333333333
+            201.0 303.0 306.0 309.0 312.0 209.0
+            268.0 404.0 408.0 412.0 416.0 278.66666666667
+            201.0 303.0 306.0 309.0 312.0 209.0
+        ]
+        @test C1 == SC1 
+        @test A1[2:end-1, 2:end-1] == C1 == SC1 == r[2:end-1, 2:end-1]
 
-    # Reflect
-    r = (1.0:5.0) * (100.0:105.0)'
-    A = StencilArray(r, Window{1,2}(); padding=Conditional(), boundary=Reflect());
-    B = StencilArray(r, Window{1,2}(); padding=Halo{:out}(), boundary=Reflect());
-    C = StencilArray(copy(r), Window{1,2}(); padding=Halo{:in}(), boundary=Reflect());
-    @time A1 = mapstencil(mean, A)
-    @time B1 = mapstencil(mean, B)
-    @time C1 = mapstencil(mean, C)
-    @test A1[3:end-2, 3:end-2] == B1[3:end-2, 3:end-2] == C1[2:end-1, 2:end-1]
-    # # Not sure about this one yet
-    @test A1[2:end-1, 2:end-1] == B1[2:end-1, 2:end-1]
-    @test A1[2:end-1, 2:end-1] != C1
-    parent(A)
-    parent(B)
-    parent(C)
+        # `sum` gives a different array
+        @time A1 = mapstencil(sum, A)
+        @time B1 = mapstencil(sum, B)
+        @time C1 = mapstencil(sum, C)
+        @time SA1 = mapstencil!(sum, SA)
+        @time SB1 = mapstencil!(sum, SB)
+        @time SC1 = mapstencil!(sum, SC)
+        @test A1 == B1 == SA1 == SB1
+        @test A1[2:end-1, 2:end-1] == C1 == SC1 == [
+            1818.0  1836.0  1854.0  1872.0
+            2727.0  2754.0  2781.0  2808.0
+            3636.0  3672.0  3708.0  3744.0
+        ]
+    end
 
+    @testset "Wrap" begin
+        @testset "1d" begin
+            s = Window{1,1}()
+            x = collect(1.0:5.0)
+            A = StencilArray(x, s; padding=Conditional(), boundary=Wrap());
+            B = StencilArray(x, s; padding=Halo{:out}(), boundary=Wrap());
+            C = StencilArray(copy(x), s; padding=Halo{:in}(), boundary=Wrap());
+            SA = SwitchingStencilArray(copy(x), s; padding=Conditional(), boundary=Wrap());
+            SB = SwitchingStencilArray(copy(x), s; padding=Halo{:out}(), boundary=Wrap());
+            SC = SwitchingStencilArray(copy(x), s; padding=Halo{:in}(), boundary=Wrap());
+
+            @time A1 = mapstencil(mean, A)
+            @time B1 = mapstencil(mean, B)
+            @time C1 = mapstencil(mean, C)
+            @time SA1 = mapstencil!(mean, SA)
+            @time SB1 = mapstencil!(mean, SB);
+            @time SC1 = mapstencil!(mean, SC)
+            @test A1 == B1 == SA1 == [2.6666666666666665, 2.0, 3.0, 4.0, 3.3333333333333335]
+            @test C1 == SC1 == [3.0, 3.0, 3.0]
+        end
+        @testset "2d" begin
+            s = Window{1,2}()
+            r = (1.0:5.0) * (100.0:105.0)'
+            A = StencilArray(r, s; padding=Conditional(), boundary=Wrap());
+            B = StencilArray(r, s; padding=Halo{:out}(), boundary=Wrap());
+            C = StencilArray(copy(r), s; padding=Halo{:in}(), boundary=Wrap());
+            SA = SwitchingStencilArray(copy(r), s; padding=Conditional(), boundary=Wrap());
+            SB = SwitchingStencilArray(copy(r), s; padding=Halo{:out}(), boundary=Wrap());
+            SC = SwitchingStencilArray(copy(r), s; padding=Halo{:in}(), boundary=Wrap());
+
+            @time A1 = mapstencil(mean, A)
+            @time B1 = mapstencil(mean, B)
+            @time C1 = mapstencil(mean, C)
+            @time SA1 = mapstencil!(mean, SA)
+            @time SB1 = mapstencil!(mean, SB)
+            @time SC1 = mapstencil!(mean, SC)
+            @test A1 == B1 == SA1 == SB1 ≈ [
+                272.0 269.33333333 272.0  274.66666666 277.33333333 274.66666666
+                204.0 202.0        204.0  206.0        208.0        206.0
+                306.0 303.0        306.0  309.0        312.0        309.0
+                408.0 404.0        408.0  412.0        416.0        412.0
+                340.0 336.66666666 340.0  343.33333333 346.66666666 343.33333333
+            ]
+            @test C1 == SC1 
+        end
+    end
+
+    @testset "Reflect" begin
+        @testset "1d" begin
+            r = collect(1.0:5.0)
+            s = Window{1,1}()
+            A = StencilArray(r, s; padding=Conditional(), boundary=Reflect());
+            B = StencilArray(r, s; padding=Halo{:out}(), boundary=Reflect());
+            C = StencilArray(copy(r), s; padding=Halo{:in}(), boundary=Reflect());
+            SA = SwitchingStencilArray(copy(r), s; padding=Conditional(), boundary=Reflect());
+            SB = SwitchingStencilArray(copy(r), s; padding=Halo{:out}(), boundary=Reflect());
+            SC = SwitchingStencilArray(copy(r), s; padding=Halo{:in}(), boundary=Reflect());
+
+            @time A1 = mapstencil(mean, A)
+            @time B1 = mapstencil(mean, B) 
+            @time C1 = mapstencil(mean, C)
+            @time SA1 = mapstencil!(mean, SA)
+            @time SB1 = mapstencil!(mean, SB)
+            @time SC1 = mapstencil!(mean, SC)
+            @test A1 == B1 == SA1 == SB1 ≈ [1.66666666, 2.0, 3.0, 4.0, 4.33333333]
+            @test C1 == SC1 ≈ [2.66666666, 3.0, 3.33333333]
+        end
+        @testset "2d" begin
+            r = (1.0:5.0) * (100.0:105.0)'
+            s = Window{1,2}()
+            A = StencilArray(r, s; padding=Conditional(), boundary=Reflect());
+            B = StencilArray(r, s; padding=Halo{:out}(), boundary=Reflect());
+            C = StencilArray(copy(r), s; padding=Halo{:in}(), boundary=Reflect());
+            SA = SwitchingStencilArray(copy(r), s; padding=Conditional(), boundary=Reflect());
+            SB = SwitchingStencilArray(copy(r), s; padding=Halo{:out}(), boundary=Reflect());
+            SC = SwitchingStencilArray(copy(r), s; padding=Halo{:in}(), boundary=Reflect());
+
+            @time A1 = mapstencil(mean, A)
+            @time B1 = mapstencil(mean, B) 
+            @time C1 = mapstencil(mean, C)
+            @time SA1 = mapstencil!(mean, SA)
+            @time SB1 = mapstencil!(mean, SB)
+            @time SC1 = mapstencil!(mean, SC)
+            @test A1 == B1 == SA1 == SB1 ≈ [
+                167.77777777 168.33333333 170.0 171.66666666 173.33333333 173.888888888
+                201.33333333 202.0        204.0 206.0        208.0        208.666666666
+                302.0        303.0        306.0 309.0        312.0        313.0
+                402.66666666 404.0        408.0 412.0        416.0        417.333333333
+                436.22222222 437.66666666 442.0 446.33333333 450.66666666 452.111111111
+            ]
+            @test C1 == SC1 
+            @test A1[3:end-2, 3:end-2] == C1[2:end-1, 2:end-1] == SC1[2:end-1, 2:end-1]
+
+            @test A1[2:end-1, 2:end-1] == B1[2:end-1, 2:end-1] == SA1[2:end-1, 2:end-1] == SB1[2:end-1, 2:end-1] == r[2:end-1, 2:end-1]
+            @test A1[2:end-1, 2:end-1] != C1
+        end
+    end
 
     @testset "Wrapper array types propagate" begin
         A = DimArray(r, (X(10:10:50), Y(1.0:6.0)))
@@ -199,7 +288,7 @@ end
     S .= S2
     @test S == S2
 end
-##
+
 @testset "copy" begin
     S = StencilArray(ones(6, 7), Moore{1,2}());
     Scopy = copy(S)
@@ -212,5 +301,4 @@ end
     S = SwitchingStencilArray(ones(6, 7), Moore{1,2}(); padding=Halo{:out}(), boundary=Wrap());
     Scopy = copy(S)
     @test S == Scopy
-    
 end


### PR DESCRIPTION
This PR fixes and tests a few bugs with `SwitchingStencilArray`

Notably, it fixes some `update_boundary!` bugs by deleting a few hundred lines of code and instead using the same generated function for all boundary conditions, `bounded_index` to provide the inbounds source values for the out of bounds padding.