### PR TITLE
Add Annulus, Ordinal and Cardinal shapes.

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -27,6 +27,9 @@ Rectangle
 Vertical
 VonNeumann
 Window
+Annulus
+Cardinal
+Ordinal
 ```
 
 ## Stencil functions

--- a/src/Stencils.jl
+++ b/src/Stencils.jl
@@ -8,8 +8,9 @@ using Adapt,
 
 import SparseArrays
 
-export Stencil, Window, Rectangle, Kernel, Moore, VonNeumann, Positional, Layered, 
-    Circle, Cross, AngledCross, BackSlash, ForwardSlash, Vertical, Horizontal, Diamond, NamedStencil
+export Stencil, Window, Rectangle, Kernel, Moore, VonNeumann, Positional, Layered,
+    Circle, Cross, AngledCross, BackSlash, ForwardSlash, Vertical, Horizontal, Diamond,
+    NamedStencil, Annulus, Cardinal, Ordinal
 
 export StencilArray, SwitchingStencilArray
 

--- a/src/stencils/named.jl
+++ b/src/stencils/named.jl
@@ -80,3 +80,6 @@ offsets(::Type{<:NamedStencil{<:Any,O}}) where O = SVector(O)
 @inline function rebuild(n::NamedStencil{K,O,R,N,L}, neighbors) where {K,O,R,N,L}
     NamedStencil{K,O,R,N,L}(neighbors)
 end
+
+NamedStencil(s::Cardinal) = NamedStencil{(:E, :S, :N, :W)}(s)
+NamedStencil(s::Ordinal) = NamedStencil{(:SE, :NE, :SW, :NW)}(s)

--- a/src/stencils/shapes.jl
+++ b/src/stencils/shapes.jl
@@ -102,3 +102,66 @@ end
     end
     return :(SVector($offsets_expr))
 end
+
+# Custom macroexpand of the `@stencil` because of two radii
+"""
+Annulus <: Stencil
+
+Annulus(; outer_radius=2, inner_radius=1, ndims=2)
+Annulus(outer_radius, inner_radius, ndims)
+Annulus{RO,RI,N}()
+
+A donut or hollowed spherical stencil
+"""
+struct Annulus{RO,RI,N,L,T} <: Stencil{RO,N,L,T}  # Inner radius is ignored for Stencil type
+    neighbors::SVector{L,T}
+    Annulus{RO,RI,N,L,T}(neighbors::StaticVector{L,T}) where {RO,RI,N,L,T} = new{RO,RI,N,L,T}(neighbors)
+end
+Annulus{RO,RI,N,L}(neighbors::StaticVector{L,T}) where {RO,RI,N,L,T} = Annulus{RO,RI,N,L,T}(neighbors)
+Annulus{RO,RI,N,L}() where {RO,RI,N,L} = Annulus{RO,RI,N,L}(SVector(ntuple(_ -> nothing, L)))
+function Annulus{RO,RI,N}(args::StaticVector...) where {RO,RI,N}
+    L = length(offsets(Annulus{RO,RI,N}))
+    Annulus{RO,RI,N,L}(args...)
+end
+Annulus{RO}(args::StaticVector...) where {RO} = Annulus{RO,RO - 1,2}(args...)
+Annulus{RO,RI}(args::StaticVector...) where {RO,RI} = Annulus{RO,RI,2}(args...)
+Annulus(args::StaticVector...; outer_radius=2, inner_radius=1, ndims=2) = Annulus{outer_radius,inner_radius,ndims}(args...)
+Annulus(outer_radius::Int, inner_radius::Int=outer_radius - 1, ndims::Int=2) = Annulus{outer_radius,inner_radius,ndims}()
+
+@inline Stencils.rebuild(n::Annulus{RO,RI,N,L}, neighbors) where {RO,RI,N,L} = Annulus{RO,RI,N,L}(neighbors)
+
+@generated function offsets(::Type{<:Annulus{RO,RI,N}}) where {RO,RI,N}
+    offsets_expr = Expr(:tuple)
+    for I in CartesianIndices(ntuple(_ -> -RO:RO, N))
+        # If the center of the pixel is inside the radius
+        dist = sqrt(sum(map(x -> x^2, Tuple(I))))
+        if dist < RO + 0.5 && dist >= RI + 0.5
+            push!(offsets_expr.args, Tuple(I))
+        end
+    end
+    return :(SVector($offsets_expr))
+end
+
+@stencil Cardinal "Cardinal (as in N,S,W,E compass directions) stencil"
+@generated function offsets(::Type{<:Cardinal{R,N}}) where {R,N}
+    offsets_expr = Expr(:tuple)
+    for I in CartesianIndices(ntuple(_ -> -R:R, N))
+        CI = abs.(Tuple(I))
+        if sum(CI) == R && maximum(CI) == R
+            push!(offsets_expr.args, Tuple(I))
+        end
+    end
+    return :(SVector($offsets_expr))
+end
+
+@stencil Ordinal "Ordinal (as in NE,SE,SW,NW wind directions) stencil"
+@generated function offsets(::Type{<:Ordinal{R,N}}) where {R,N}
+    offsets_expr = Expr(:tuple)
+    for I in CartesianIndices(ntuple(_ -> -R:R, N))
+        CI = abs.(Tuple(I))
+        if sum(CI) == R * N && maximum(CI) == R
+            push!(offsets_expr.args, Tuple(I))
+        end
+    end
+    return :(SVector($offsets_expr))
+end

--- a/test/stencils.jl
+++ b/test/stencils.jl
@@ -71,6 +71,58 @@ end
     @test offsets(vonneumann2) == SVector((0, -2), (-1, -1), (0, -1), (1, -1),
          (-2 , 0), (-1, 0), (1, 0), (2, 0),
          (-1, 1), (0, 1), (1, 1), (0, 2))
+
+@testset "Annulus" begin
+    h = Annulus{1}()
+    A = StencilArray(init, h)
+    annulus = Stencils.rebuild(h, neighbors(A, (2, 2)))
+    @test offsets(annulus) == SVector((-1, -1), (0, -1), (1, -1), (-1, 0), (1, 0), (-1, 1),
+        (0, 1), (1, 1))
+    @test radius(annulus) == 1
+    @test diameter(annulus) == 3
+    @test annulus[1] == 0
+    @test annulus[2] == 1
+    @test length(annulus) == 8
+    @test eltype(annulus) == Int
+    @test neighbors(annulus) == SVector(0, 1, 0, 0, 1, 0, 1, 1)
+    @test sum(neighbors(annulus)) == sum(annulus) == 4
+    annulus2 = Annulus{2}()
+    @test offsets(annulus2) == SVector((-1, -2), (0, -2), (1, -2), (-2, -1), (2, -1),
+        (-2, 0), (2, 0), (-2, 1), (2, 1), (-1, 2), (0, 2), (1, 2))
+end
+
+@testset "Ordinal" begin
+    h = Ordinal{1}()
+    A = StencilArray(init, h)
+    ordinal = Stencils.rebuild(h, neighbors(A, (2, 2)))
+    @test offsets(ordinal) == SVector((-1, -1), (1, -1), (-1, 1), (1, 1))
+    @test radius(ordinal) == 1
+    @test diameter(ordinal) == 3
+    @test ordinal[1] == 0
+    @test ordinal[4] == 1
+    @test length(ordinal) == 4
+    @test eltype(ordinal) == Int
+    @test neighbors(ordinal) == SVector(0, 0, 0, 1)
+    @test sum(neighbors(ordinal)) == sum(ordinal) == 1
+    ordinal2 = Ordinal{2}()
+    @test offsets(ordinal2) == SVector((-2, -2), (2, -2), (-2, 2), (2, 2))
+end
+
+@testset "Cardinal" begin
+    h = Cardinal{1}()
+    A = StencilArray(init, h)
+    cardinal = Stencils.rebuild(h, neighbors(A, (2, 2)))
+    @test offsets(cardinal) == SVector((0, -1), (-1, 0), (1, 0), (0, 1))
+    @test radius(cardinal) == 1
+    @test diameter(cardinal) == 3
+    @test cardinal[1] == 1
+    @test cardinal[2] == 0
+    @test length(cardinal) == 4
+    @test eltype(cardinal) == Int
+    @test neighbors(cardinal) == SVector(1, 0, 1, 1)
+    @test sum(neighbors(cardinal)) == sum(cardinal) == 3
+    cardinal2 = Cardinal{2}()
+    @test offsets(cardinal2) == SVector((0, -2), (-2, 0), (2, 0), (0, 2))
 end
 
 @testset "Positional" begin

--- a/test/stencils.jl
+++ b/test/stencils.jl
@@ -71,6 +71,7 @@ end
     @test offsets(vonneumann2) == SVector((0, -2), (-1, -1), (0, -1), (1, -1),
          (-2 , 0), (-1, 0), (1, 0), (2, 0),
          (-1, 1), (0, 1), (1, 1), (0, 2))
+end
 
 @testset "Annulus" begin
     h = Annulus{1}()

--- a/test/stencils.jl
+++ b/test/stencils.jl
@@ -203,6 +203,29 @@ end
     # Shorthand syntax for naming another stencil
     @test h1 == NamedStencil{(:n,:e,:w,:s)}(VonNeumann())
     @test_throws ArgumentError NamedStencil{(:n,:s)}(VonNeumann())
+
+    # Cardinal and Ordinal (fixed wind directions) can be used as NamedStencils
+    ns = NamedStencil(Cardinal(1))
+    @test mapstencil(StencilArray(win, ns)) do s
+        s.W + s.S
+    end == [
+        1 0 0 1 0
+        0 2 0 0 1
+        0 0 2 1 0
+        0 1 0 2 1
+        0 1 1 1 1
+    ]
+
+    ns = NamedStencil(Ordinal(1))
+    @test mapstencil(StencilArray(win, ns)) do s
+        s.NE + s.NW
+    end == [
+        0 1 0 1 0
+        0 0 1 1 1
+        0 1 0 2 0
+        0 2 0 2 0
+        0 0 0 0 0
+    ]
 end
 
 @testset "Layered" begin


### PR DESCRIPTION
```julia
julia> Cardinal(2)  # N S W E
Cardinal{2, 2, 4, Nothing}
  ▀  
▀   ▀
  ▀  


julia> Ordinal(2)  # NE, SE, SW, NW
Ordinal{2, 2, 4, Nothing}
▀   ▀
     
▀   ▀


julia> Annulus(3)  # Hollow circle (Donut in 2D)
Annulus{3, 2, 2, 16, Nothing}
 ▄▀▀▀▄ 
█     █
▀▄   ▄▀
  ▀▀▀  
```

I wonder about always specializing `NamedStencil` on Cardinal and Ordinal to always provide the compass directions. And there's `Layered`, but it might be good to have a shortcut to merge `Ordinal` and `Cardinal` (including the `NamedStencil` variants)?