### PR TITLE
Add center to Stencils.

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,6 +36,7 @@ These can be called on any `<: Stencil` object, and `Layered`.
 ```@docs
 stencil
 neighbors
+center
 offsets
 indices
 distances

--- a/src/Stencils.jl
+++ b/src/Stencils.jl
@@ -17,7 +17,7 @@ export Remove, Use, Wrap, Reflect
 
 export Conditional, Halo
 
-export stencil, neighbors, offsets, indices, distances, kernelproduct, radius, diameter
+export stencil, neighbors, center, offsets, indices, distances, kernelproduct, radius, diameter
 export mapstencil, mapstencil!, switch
 
 include("stencil.jl")

--- a/src/array.jl
+++ b/src/array.jl
@@ -26,8 +26,11 @@ Base.@propagate_inbounds stencil(A::AbstractStencilArray, I::Union{CartesianInde
 Base.@propagate_inbounds stencil(A::AbstractStencilArray, I::CartesianIndex) =
     stencil(stencil(A), A, I)
 Base.@propagate_inbounds stencil(hood::StencilOrLayered, A::AbstractStencilArray, I::CartesianIndex) =
-    rebuild(hood, neighbors(hood, A, I))
+    rebuild(hood, _center(hood, A, I), neighbors(hood, A, I))
 Base.@propagate_inbounds stencil(A::AbstractStencilArray) = A.stencil
+
+@inline _center(::Stencil, A::AbstractStencilArray, I::CartesianIndex) = A[I]
+@inline _center(hood::Layered, A::AbstractStencilArray, I::CartesianIndex) = map(l -> _center(l, A, I), hood)
 
 """
     unsafe_stencil(x, A::AbstractArray, I) => Stencil
@@ -39,7 +42,7 @@ with the assumption that `I` is inbounds.
 @inline unsafe_stencil(A::AbstractStencilArray, I::CartesianIndex) =
     unsafe_stencil(stencil(A), A, I)
 @inline unsafe_stencil(hood::StencilOrLayered, A::AbstractStencilArray, I::CartesianIndex) =
-    rebuild(hood, unsafe_neighbors(hood, A, I))
+    rebuild(hood, _center(hood, A, I), unsafe_neighbors(hood, A, I))
 
 """
     boundary(A::AbstractStencilArray)

--- a/src/array.jl
+++ b/src/array.jl
@@ -26,7 +26,7 @@ Base.@propagate_inbounds stencil(A::AbstractStencilArray, I::Union{CartesianInde
 Base.@propagate_inbounds stencil(A::AbstractStencilArray, I::CartesianIndex) =
     stencil(stencil(A), A, I)
 Base.@propagate_inbounds stencil(hood::StencilOrLayered, A::AbstractStencilArray, I::CartesianIndex) =
-    rebuild(hood, _center(hood, A, I), neighbors(hood, A, I))
+    rebuild(hood, neighbors(hood, A, I), _center(hood, A, I))
 Base.@propagate_inbounds stencil(A::AbstractStencilArray) = A.stencil
 
 @inline _center(::Stencil, A::AbstractStencilArray, I::CartesianIndex) = A[I]
@@ -42,7 +42,7 @@ with the assumption that `I` is inbounds.
 @inline unsafe_stencil(A::AbstractStencilArray, I::CartesianIndex) =
     unsafe_stencil(stencil(A), A, I)
 @inline unsafe_stencil(hood::StencilOrLayered, A::AbstractStencilArray, I::CartesianIndex) =
-    rebuild(hood, _center(hood, A, I), unsafe_neighbors(hood, A, I))
+    rebuild(hood, unsafe_neighbors(hood, A, I), _center(hood, A, I))
 
 """
     boundary(A::AbstractStencilArray)

--- a/src/mapstencil.jl
+++ b/src/mapstencil.jl
@@ -38,7 +38,7 @@ function _return_type(f, A::AbstractStencilArray{<:Any,<:Any,T}, args...) where 
     bc = boundary(A)
     T1 = bc isa Remove ? promote_type(T, typeof(padval(bc))) : T
     emptyneighbors = _zero_values(T1, st)
-    H = typeof(rebuild(st, emptyneighbors))
+    H = typeof(rebuild(st, zero(T1), emptyneighbors))
     # Use nasty broadcast mechanism `_return_type` to get the new eltype
     return Base._return_type(f, Tuple{H,map(eltype, args)...})
 end
@@ -144,6 +144,7 @@ function _checksizes(sources::Tuple)
     return nothing
 end
 
+# TODO These methods have unused variables and don't seem to be used anywhere
 function applystencil(f, hood, sources::Tuple, I)
     hoods = map(s -> stencil(s, I), sources)
     vals = map(s -> s[I], sources)

--- a/src/mapstencil.jl
+++ b/src/mapstencil.jl
@@ -38,12 +38,14 @@ function _return_type(f, A::AbstractStencilArray{<:Any,<:Any,T}, args...) where 
     bc = boundary(A)
     T1 = bc isa Remove ? promote_type(T, typeof(padval(bc))) : T
     emptyneighbors = _zero_values(T1, st)
-    H = typeof(rebuild(st, emptyneighbors, zero(T1)))
+    emptycenters = _zero_center(T1, st)
+    H = typeof(rebuild(st, emptyneighbors, emptycenters))
     # Use nasty broadcast mechanism `_return_type` to get the new eltype
     return Base._return_type(f, Tuple{H,map(eltype, args)...})
 end
 
 _zero_values(::Type{T}, ::Stencil{<:Any,<:Any,L}) where {T,L} = SVector{L,T}(ntuple(_ -> zero(T), L))
+_zero_center(::Type{T}, ::Stencil) where T = zero(T)
 
 kernel_setup() = KernelAbstractions.CPU(; static=true), 64
 

--- a/src/mapstencil.jl
+++ b/src/mapstencil.jl
@@ -38,7 +38,7 @@ function _return_type(f, A::AbstractStencilArray{<:Any,<:Any,T}, args...) where 
     bc = boundary(A)
     T1 = bc isa Remove ? promote_type(T, typeof(padval(bc))) : T
     emptyneighbors = _zero_values(T1, st)
-    H = typeof(rebuild(st, zero(T1), emptyneighbors))
+    H = typeof(rebuild(st, emptyneighbors, zero(T1)))
     # Use nasty broadcast mechanism `_return_type` to get the new eltype
     return Base._return_type(f, Tuple{H,map(eltype, args)...})
 end

--- a/src/stencil.jl
+++ b/src/stencil.jl
@@ -100,7 +100,7 @@ Base.@propagate_inbounds indexat(hood::Stencil, center, i) = CartesianIndex(offs
 """
     center(x::Stencil)
 
-Return the value of the central cell in the stencil.
+Return the value of the central cell a stencil is offset around. It may or may not be part of the stencil itself.
 """
 center(hood::Stencil) = getfield(hood, :center)
 

--- a/src/stencil.jl
+++ b/src/stencil.jl
@@ -231,21 +231,21 @@ macro stencil(name, description)
 
     struct_expr = quote
         struct $name{R,N,L,T} <: Stencil{R,N,L,T}
-            center::T
             neighbors::SVector{L,T}
-            $name{R,N,L,T}(center::T, neighbors::StaticVector{L,T}) where {R,N,L,T} = new{R,N,L,T}(center, neighbors)
+            center::T
+            $name{R,N,L,T}(neighbors::StaticVector{L,T}, center::T) where {R,N,L,T} = new{R,N,L,T}(neighbors,center)
         end
     end
     func_exprs = quote
         
         # Filled stencils
-        $name{R,N,L}(center::T, neighbors::StaticVector{L,T}) where {R,N,L,T} = $name{R,N,L,T}(center, neighbors)
-        $name{R,N}(center::T, neighbors::StaticVector{L,T}) where {R,N,L,T} = $name{R,N,L,T}(center, neighbors)
-        $name{R}(center, args::StaticVector) where R = $name{R,2}(center, args)
-        $name(center, args::StaticVector; radius=1, ndims=2) = $name{radius,ndims}(center, args)
+        $name{R,N,L}(neighbors::StaticVector{L,T}, center::T) where {R,N,L,T} = $name{R,N,L,T}(neighbors,center)
+        $name{R,N}(neighbors::StaticVector{L,T}, center::T) where {R,N,L,T} = $name{R,N,L,T}(neighbors,center)
+        $name{R}(args::StaticVector, center) where R = $name{R,2}(args, center)
+        $name(args::StaticVector, center; radius=1, ndims=2) = $name{radius,ndims}(args, center)
 
         # Empty stencils
-        $name{R,N,L}() where {R,N,L} = $name{R,N,L}(nothing, SVector(ntuple(_ -> nothing, L)))
+        $name{R,N,L}() where {R,N,L} = $name{R,N,L}(SVector(ntuple(_ -> nothing, L)), nothing)
         function $name{R,N}() where {R,N}
             L = length(offsets($name{R,N}))
             $name{R,N,L}()
@@ -254,7 +254,7 @@ macro stencil(name, description)
         $name(; radius=1, ndims=2) = $name{radius,ndims}()
         $name(radius::Int, ndims::Int=2) = $name{radius,ndims}()
 
-        @inline Stencils.rebuild(n::$name{R,N,L}, center, neighbors) where {R,N,L} = $name{R,N,L}(center, neighbors)
+        @inline Stencils.rebuild(n::$name{R,N,L}, neighbors, center) where {R,N,L} = $name{R,N,L}(neighbors, center)
     end
     return Expr(:block, :(Base.@doc $docstring $struct_expr), func_exprs)
 end

--- a/src/stencil.jl
+++ b/src/stencil.jl
@@ -8,8 +8,8 @@ They reduce the structure and dimensions of the neighborhood into a
 Stencil objects are updated to contain the neighbors for an array index.
 
 This design is so that user functions can be passed a single object from
-which they can retrieve neighbors, offsets, distances to neighbors and other
-information.
+which they can retrieve center, neighbors, offsets, distances to neighbors
+and other information.
 
 Stencils also provide a range of compile-time utility funcitons like
 `distances` and `offsets`.

--- a/src/stencils/kernel.jl
+++ b/src/stencils/kernel.jl
@@ -1,6 +1,7 @@
 abstract type AbstractKernelStencil{R,N,L,T,H} <: Stencil{R,N,L,T} end
 
 neighbors(hood::AbstractKernelStencil) = neighbors(stencil(hood))
+center(hood::AbstractKernelStencil) = center(stencil(hood))
 offsets(::Type{<:AbstractKernelStencil{<:Any,<:Any,<:Any,<:Any,H}}) where H = offsets(H)
 positions(hood::AbstractKernelStencil, I::Tuple) = positions(stencil(hood), I)
 
@@ -116,8 +117,8 @@ end
 
 # We *dont* want `rebuild` to trigger kernel function rebuilds
 # so we can update the neighborhood with no runtime cost
-function rebuild(n::Kernel{R,N,L}, neighbors,center) where {R,N,L}
-    hood = rebuild(stencil(n), neighbors,center)
+function rebuild(n::Kernel{R,N,L}, neighbors, center) where {R,N,L}
+    hood = rebuild(stencil(n), neighbors, center)
     return Kernel{R,N,L,eltype(hood),typeof(n.f),typeof(hood),typeof(kernel(n))}(n.f, hood, kernel(n))
 end
 

--- a/src/stencils/kernel.jl
+++ b/src/stencils/kernel.jl
@@ -116,8 +116,8 @@ end
 
 # We *dont* want `rebuild` to trigger kernel function rebuilds
 # so we can update the neighborhood with no runtime cost
-function rebuild(n::Kernel{R,N,L}, neighbors) where {R,N,L}
-    hood = rebuild(stencil(n), neighbors)
+function rebuild(n::Kernel{R,N,L}, center, neighbors) where {R,N,L}
+    hood = rebuild(stencil(n), center, neighbors)
     return Kernel{R,N,L,eltype(hood),typeof(n.f),typeof(hood),typeof(kernel(n))}(n.f, hood, kernel(n))
 end
 

--- a/src/stencils/kernel.jl
+++ b/src/stencils/kernel.jl
@@ -116,8 +116,8 @@ end
 
 # We *dont* want `rebuild` to trigger kernel function rebuilds
 # so we can update the neighborhood with no runtime cost
-function rebuild(n::Kernel{R,N,L}, center, neighbors) where {R,N,L}
-    hood = rebuild(stencil(n), center, neighbors)
+function rebuild(n::Kernel{R,N,L}, neighbors,center) where {R,N,L}
+    hood = rebuild(stencil(n), neighbors,center)
     return Kernel{R,N,L,eltype(hood),typeof(n.f),typeof(hood),typeof(kernel(n))}(n.f, hood, kernel(n))
 end
 

--- a/src/stencils/layered.jl
+++ b/src/stencils/layered.jl
@@ -53,3 +53,5 @@ indices(layered::Layered, I::Tuple) = map(l -> indices(l, I), layered)
 
 _zero_values(::Type{T}, l::Layered) where T =
     map(l -> _zero_values(T, l), layers(l))
+_zero_center(::Type{T}, l::Layered) where T =
+    map(l -> _zero_center(T, l), layers(l))

--- a/src/stencils/layered.jl
+++ b/src/stencils/layered.jl
@@ -39,8 +39,8 @@ layers(stencil::Layered) = Base.getfield(stencil, :layers)
 @inline offsets(::Type{<:Layered{R,N,L,T,La}}) where {R,N,L,T,La} =
     map(p -> offsets(p), tuple_contents(La))
 
-@inline function rebuild(h::Layered{R,N,L,T}, centers, layerneighbors) where {R,N,L,T}
-    Layered{R,N,L,T}(map(rebuild, layers(h), centers, layerneighbors))
+@inline function rebuild(h::Layered{R,N,L,T}, layerneighbors, centers) where {R,N,L,T}
+    Layered{R,N,L,T}(map(rebuild, layers(h), layerneighbors, centers))
 end
 
 for f in (:center, :neighbors, :offsets, :cartesian_offsets, :distances, :distance_zones)

--- a/src/stencils/layered.jl
+++ b/src/stencils/layered.jl
@@ -39,11 +39,11 @@ layers(stencil::Layered) = Base.getfield(stencil, :layers)
 @inline offsets(::Type{<:Layered{R,N,L,T,La}}) where {R,N,L,T,La} =
     map(p -> offsets(p), tuple_contents(La))
 
-@inline function rebuild(h::Layered{R,N,L,T}, layerneighbors) where {R,N,L,T}
-    Layered{R,N,L,T}(map(rebuild, layers(h), layerneighbors))
+@inline function rebuild(h::Layered{R,N,L,T}, centers, layerneighbors) where {R,N,L,T}
+    Layered{R,N,L,T}(map(rebuild, layers(h), centers, layerneighbors))
 end
 
-for f in (:neighbors, :offsets, :cartesian_offsets, :distances, :distance_zones)
+for f in (:center, :neighbors, :offsets, :cartesian_offsets, :distances, :distance_zones)
     @eval $f(layered::Layered) = map($f, layered)
 end
 

--- a/src/stencils/named.jl
+++ b/src/stencils/named.jl
@@ -41,17 +41,17 @@ and the dimensionality `N` of the stencil is taken from the length of
 the first coordinate, e.g. `1`, `2` or `3`.
 """
 struct NamedStencil{K,O,R,N,L,T} <: Stencil{R,N,L,T}
-    center::T
     neighbors::SVector{L,T}
-    function NamedStencil{K,O,R,N,L,T}(center::T, neighbors::SVector{L,T}) where {K,O,R,N,L,T}
+    center::T
+    function NamedStencil{K,O,R,N,L,T}(neighbors::SVector{L,T},center::T) where {K,O,R,N,L,T}
         length(K) == length(O) == L || throw(ArgumentError("Length of keys must match length of offsets and L parameter"))
-        new{K,O,R,N,L,T}(center, neighbors)
+        new{K,O,R,N,L,T}(neighbors, center)
     end
 end
-NamedStencil{K,O,R,N,L}(center::T, neighbors::SVector{L,T}) where {K,O,R,N,L,T} =
-    NamedStencil{K,O,R,N,L,T}(center, neighbors)
+NamedStencil{K,O,R,N,L}(neighbors::SVector{L,T},center::T) where {K,O,R,N,L,T} =
+    NamedStencil{K,O,R,N,L,T}(neighbors, center)
 NamedStencil{K,O,R,N,L}() where {K,O,R,N,L} =
-    NamedStencil{K,O,R,N,L}(nothing, SVector(ntuple(_ -> nothing, L)))
+    NamedStencil{K,O,R,N,L}(SVector(ntuple(_ -> nothing, L)), nothing)
 function NamedStencil{K,O}() where {K,O}
     N = length(first(O))
     R = _positional_radii(N, O)
@@ -78,6 +78,6 @@ end
 
 offsets(::Type{<:NamedStencil{<:Any,O}}) where O = SVector(O)
 
-@inline function rebuild(::NamedStencil{K,O,R,N,L}, center, neighbors) where {K,O,R,N,L}
-    NamedStencil{K,O,R,N,L}(center, neighbors)
+@inline function rebuild(::NamedStencil{K,O,R,N,L}, neighbors, center) where {K,O,R,N,L}
+    NamedStencil{K,O,R,N,L}(neighbors, center)
 end

--- a/src/stencils/named.jl
+++ b/src/stencils/named.jl
@@ -41,16 +41,17 @@ and the dimensionality `N` of the stencil is taken from the length of
 the first coordinate, e.g. `1`, `2` or `3`.
 """
 struct NamedStencil{K,O,R,N,L,T} <: Stencil{R,N,L,T}
+    center::T
     neighbors::SVector{L,T}
-    function NamedStencil{K,O,R,N,L,T}(neighbors::SVector{L,T}) where {K,O,R,N,L,T}
+    function NamedStencil{K,O,R,N,L,T}(center::T, neighbors::SVector{L,T}) where {K,O,R,N,L,T}
         length(K) == length(O) == L || throw(ArgumentError("Length of keys must match length of offsets and L parameter"))
-        new{K,O,R,N,L,T}(neighbors)
+        new{K,O,R,N,L,T}(center, neighbors)
     end
 end
-NamedStencil{K,O,R,N,L}(neighbors::SVector{L,T}) where {K,O,R,N,L,T} =
-    NamedStencil{K,O,R,N,L,T}(neighbors)
+NamedStencil{K,O,R,N,L}(center::T, neighbors::SVector{L,T}) where {K,O,R,N,L,T} =
+    NamedStencil{K,O,R,N,L,T}(center, neighbors)
 NamedStencil{K,O,R,N,L}() where {K,O,R,N,L} =
-    NamedStencil{K,O,R,N,L}(SVector(ntuple(_ -> nothing, L)))
+    NamedStencil{K,O,R,N,L}(nothing, SVector(ntuple(_ -> nothing, L)))
 function NamedStencil{K,O}() where {K,O}
     N = length(first(O))
     R = _positional_radii(N, O)
@@ -77,6 +78,6 @@ end
 
 offsets(::Type{<:NamedStencil{<:Any,O}}) where O = SVector(O)
 
-@inline function rebuild(n::NamedStencil{K,O,R,N,L}, neighbors) where {K,O,R,N,L}
-    NamedStencil{K,O,R,N,L}(neighbors)
+@inline function rebuild(::NamedStencil{K,O,R,N,L}, center, neighbors) where {K,O,R,N,L}
+    NamedStencil{K,O,R,N,L}(center, neighbors)
 end

--- a/src/stencils/positional.jl
+++ b/src/stencils/positional.jl
@@ -29,21 +29,28 @@ Positional{((0, -1), (2, 1), (-1, 1), (0, 1)), 2, 2, 4, Nothing}
 ```
 """
 struct Positional{O,R,N,L,T} <: Stencil{R,N,L,T}
+    center::T
     neighbors::SVector{L,T}
-    function Positional{O,R,N,L,T}(neighbors::SVector{L,T}) where {O,R,N,L,T} 
+    function Positional{O,R,N,L,T}(center::T, neighbors::SVector{L,T}) where {O,R,N,L,T} 
         @assert all(map(o -> length(o) == N, O)) "All offsets must be the length `N` of $N, got $O" 
-        new{O,R,N,L,T}(neighbors)
+        new{O,R,N,L,T}(center, neighbors)
     end
 end
-Positional{O,R,N,L}(neighbors::SVector{L,T}) where {O,R,N,L,T} = 
-    Positional{O,R,N,L,T}(neighbors)
+Positional{O,R,N,L}(center::T, neighbors::SVector{L,T}) where {O,R,N,L,T} = 
+    Positional{O,R,N,L,T}(center, neighbors)
 Positional{O,R,N,L}() where {O,R,N,L} = 
-    Positional{O,R,N,L}(SVector(ntuple(_ -> nothing, L)))
-function Positional{O}(args::SVector...) where O
+    Positional{O,R,N,L}(nothing, SVector(ntuple(_ -> nothing, L)))
+function Positional{O}(center, args::SVector) where O
     N = length(first(O))
     R = _positional_radii(N, O)
     L = length(O)
-    Positional{O,R,N,L}(args...)
+    Positional{O,R,N,L}(center, args)
+end
+function Positional{O}() where O
+    N = length(first(O))
+    R = _positional_radii(N, O)
+    L = length(O)
+    Positional{O,R,N,L}()
 end
 Positional(os1::CustomOffset, offsets::CustomOffset...) = Positional((os1, offsets...))
 Positional(offsets::CustomOffsets) = Positional{offsets}()
@@ -54,8 +61,8 @@ end
 
 offsets(::Type{<:Positional{O}}) where O = SVector(O)
 
-@inline function rebuild(n::Positional{O,R,N,L}, neighbors) where {O,R,N,L}
-    Positional{O,R,N,L}(neighbors)
+@inline function rebuild(::Positional{O,R,N,L}, center, neighbors) where {O,R,N,L}
+    Positional{O,R,N,L}(center, neighbors)
 end
 
 # Calculate the maximum absolute value in the offsets to use as the radius

--- a/src/stencils/positional.jl
+++ b/src/stencils/positional.jl
@@ -29,22 +29,22 @@ Positional{((0, -1), (2, 1), (-1, 1), (0, 1)), 2, 2, 4, Nothing}
 ```
 """
 struct Positional{O,R,N,L,T} <: Stencil{R,N,L,T}
-    center::T
     neighbors::SVector{L,T}
-    function Positional{O,R,N,L,T}(center::T, neighbors::SVector{L,T}) where {O,R,N,L,T} 
+    center::T
+    function Positional{O,R,N,L,T}(neighbors::SVector{L,T}, center::T) where {O,R,N,L,T} 
         @assert all(map(o -> length(o) == N, O)) "All offsets must be the length `N` of $N, got $O" 
-        new{O,R,N,L,T}(center, neighbors)
+        new{O,R,N,L,T}(neighbors, center)
     end
 end
-Positional{O,R,N,L}(center::T, neighbors::SVector{L,T}) where {O,R,N,L,T} = 
-    Positional{O,R,N,L,T}(center, neighbors)
+Positional{O,R,N,L}(neighbors::SVector{L,T}, center::T) where {O,R,N,L,T} = 
+    Positional{O,R,N,L,T}(neighbors, center)
 Positional{O,R,N,L}() where {O,R,N,L} = 
-    Positional{O,R,N,L}(nothing, SVector(ntuple(_ -> nothing, L)))
-function Positional{O}(center, args::SVector) where O
+    Positional{O,R,N,L}(SVector(ntuple(_ -> nothing, L)), nothing)
+function Positional{O}(args::SVector, center) where O
     N = length(first(O))
     R = _positional_radii(N, O)
     L = length(O)
-    Positional{O,R,N,L}(center, args)
+    Positional{O,R,N,L}(args, center)
 end
 function Positional{O}() where O
     N = length(first(O))
@@ -61,8 +61,8 @@ end
 
 offsets(::Type{<:Positional{O}}) where O = SVector(O)
 
-@inline function rebuild(::Positional{O,R,N,L}, center, neighbors) where {O,R,N,L}
-    Positional{O,R,N,L}(center, neighbors)
+@inline function rebuild(::Positional{O,R,N,L}, neighbors, center) where {O,R,N,L}
+    Positional{O,R,N,L}(neighbors, center)
 end
 
 # Calculate the maximum absolute value in the offsets to use as the radius

--- a/src/stencils/rectangle.jl
+++ b/src/stencils/rectangle.jl
@@ -11,17 +11,17 @@ specified with pulles of offsets around the center point,
 one for each dimension.
 """
 struct Rectangle{O,R,N,L,T} <: Stencil{R,N,L,T}
-    center::T
     neighbors::SVector{L,T}
-    function Rectangle{O,R,N,L,T}(center::T, neighbors::SVector{L,T}) where {O,R,N,L,T} 
-        new{O,R,N,L,T}(center, neighbors)
+    center::T
+    function Rectangle{O,R,N,L,T}(neighbors::SVector{L,T}, center::T) where {O,R,N,L,T} 
+        new{O,R,N,L,T}(neighbors, center)
     end
 end
-Rectangle{O,R,N,L}(center::T, neighbors::SVector{L,T}) where {O,R,N,L,T} = 
-    Rectangle{O,R,N,L,T}(center, neighbors)
+Rectangle{O,R,N,L}(neighbors::SVector{L,T}, center::T) where {O,R,N,L,T} = 
+    Rectangle{O,R,N,L,T}(neighbors, center)
 Rectangle{O,R,N,L}() where {O,R,N,L} = 
-    Rectangle{O,R,N,L}(nothing, SVector(ntuple(_ -> nothing, L)))
-function Rectangle{O}(center, args::SVector) where O
+    Rectangle{O,R,N,L}(SVector(ntuple(_ -> nothing, L)), nothing)
+function Rectangle{O}(args::SVector, center) where O
     all(map(o -> length(o) == 2, O)) ||
         throw(ArgumentError("All offset tuples must have length `2`, got $O"))
     N = length(O)
@@ -29,7 +29,7 @@ function Rectangle{O}(center, args::SVector) where O
         max(map(abs, o)...)
     end
     L = prod(length ∘ splat(:), O)
-    Rectangle{O,R,N,L}(center, args)
+    Rectangle{O,R,N,L}(args, center)
 end
 function Rectangle{O}() where O
     all(map(o -> length(o) == 2, O)) ||
@@ -51,6 +51,6 @@ function ConstructionBase.constructorof(::Type{Rectangle{O,R,N,L,T}}) where {O,R
     Rectangle{O,R,N,L}
 end
 
-@inline function rebuild(::Rectangle{O,R,N,L}, center, neighbors) where {O,R,N,L}
-    Rectangle{O,R,N,L}(center, neighbors)
+@inline function rebuild(::Rectangle{O,R,N,L}, neighbors, center) where {O,R,N,L}
+    Rectangle{O,R,N,L}(neighbors, center)
 end

--- a/src/stencils/shapes.jl
+++ b/src/stencils/shapes.jl
@@ -115,20 +115,28 @@ A donut or hollowed spherical stencil
 """
 struct Annulus{RO,RI,N,L,T} <: Stencil{RO,N,L,T}  # Inner radius is ignored for Stencil type
     neighbors::SVector{L,T}
-    Annulus{RO,RI,N,L,T}(neighbors::StaticVector{L,T}) where {RO,RI,N,L,T} = new{RO,RI,N,L,T}(neighbors)
+    center::T
+    Annulus{RO,RI,N,L,T}(neighbors::StaticVector{L,T}, center::T) where {RO,RI,N,L,T} = new{RO,RI,N,L,T}(neighbors, center)
 end
-Annulus{RO,RI,N,L}(neighbors::StaticVector{L,T}) where {RO,RI,N,L,T} = Annulus{RO,RI,N,L,T}(neighbors)
-Annulus{RO,RI,N,L}() where {RO,RI,N,L} = Annulus{RO,RI,N,L}(SVector(ntuple(_ -> nothing, L)))
-function Annulus{RO,RI,N}(args::StaticVector...) where {RO,RI,N}
+Annulus{RO,RI,N,L}(neighbors::StaticVector{L,T}, center::T) where {RO,RI,N,L,T} = Annulus{RO,RI,N,L,T}(neighbors, center)
+function Annulus{RO,RI,N}(args::StaticVector, center) where {RO,RI,N}
     L = length(offsets(Annulus{RO,RI,N}))
-    Annulus{RO,RI,N,L}(args...)
+    Annulus{RO,RI,N,L}(args, center)
 end
-Annulus{RO}(args::StaticVector...) where {RO} = Annulus{RO,RO - 1,2}(args...)
-Annulus{RO,RI}(args::StaticVector...) where {RO,RI} = Annulus{RO,RI,2}(args...)
-Annulus(args::StaticVector...; outer_radius=2, inner_radius=1, ndims=2) = Annulus{outer_radius,inner_radius,ndims}(args...)
+Annulus{RO,RI}(args::StaticVector) where {RO,RI} = Annulus{RO,RI,2}(args, center)
+Annulus{RO}(args::StaticVector) where {RO} = Annulus{RO,RO - 1,2}(args, center)
+Annulus(args::StaticVector, center; outer_radius=2, inner_radius=1, ndims=2) = Annulus{outer_radius,inner_radius,ndims}(args, center)
+
+Annulus{RO,RI,N,L}() where {RO,RI,N,L} = Annulus{RO,RI,N,L}(SVector(ntuple(_ -> nothing, L)), nothing)
+function Annulus{RO,RI,N}() where {RO,RI,N}
+    L = length(offsets(Annulus{RO,RI,N}))
+    Annulus{RO,RI,N,L}()
+end
+Annulus{RO,RI}() where {RO,RI} = Annulus{RO,RI,2}()
+Annulus{RO}() where {RO} = Annulus{RO,RO - 1,2}()
 Annulus(outer_radius::Int, inner_radius::Int=outer_radius - 1, ndims::Int=2) = Annulus{outer_radius,inner_radius,ndims}()
 
-@inline Stencils.rebuild(n::Annulus{RO,RI,N,L}, neighbors) where {RO,RI,N,L} = Annulus{RO,RI,N,L}(neighbors)
+@inline Stencils.rebuild(::Annulus{RO,RI,N,L}, neighbors, center) where {RO,RI,N,L} = Annulus{RO,RI,N,L}(neighbors, center)
 
 @generated function offsets(::Type{<:Annulus{RO,RI,N}}) where {RO,RI,N}
     offsets_expr = Expr(:tuple)

--- a/src/stencils/vonneumman.jl
+++ b/src/stencils/vonneumman.jl
@@ -1,5 +1,5 @@
 @stencil VonNeumann """
-Diamond-shaped neighborhood (in 2 dimwnsions), without the central cell
+Diamond-shaped neighborhood (in 2 dimensions), without the central cell
 In 1 dimension it is identical to [`Moore`](@ref).
 """
 @generated function offsets(::Type{<:VonNeumann{R,N}}) where {R,N}

--- a/test/stencils.jl
+++ b/test/stencils.jl
@@ -79,7 +79,7 @@ end
 @testset "Annulus" begin
     h = Annulus{1}()
     A = StencilArray(init, h)
-    annulus = Stencils.rebuild(h, neighbors(A, (2, 2)))
+    annulus = Stencils.rebuild(h, neighbors(A, (2, 2)), 0)
     @test offsets(annulus) == SVector((-1, -1), (0, -1), (1, -1), (-1, 0), (1, 0), (-1, 1),
         (0, 1), (1, 1))
     @test radius(annulus) == 1
@@ -89,6 +89,7 @@ end
     @test length(annulus) == 8
     @test eltype(annulus) == Int
     @test neighbors(annulus) == SVector(0, 1, 0, 0, 1, 0, 1, 1)
+    @test center(annulus) == 0
     @test sum(neighbors(annulus)) == sum(annulus) == 4
     annulus2 = Annulus{2}()
     @test offsets(annulus2) == SVector((-1, -2), (0, -2), (1, -2), (-2, -1), (2, -1),
@@ -98,7 +99,7 @@ end
 @testset "Ordinal" begin
     h = Ordinal{1}()
     A = StencilArray(init, h)
-    ordinal = Stencils.rebuild(h, neighbors(A, (2, 2)))
+    ordinal = Stencils.rebuild(h, neighbors(A, (2, 2)), 0)
     @test offsets(ordinal) == SVector((-1, -1), (1, -1), (-1, 1), (1, 1))
     @test radius(ordinal) == 1
     @test diameter(ordinal) == 3
@@ -107,6 +108,7 @@ end
     @test length(ordinal) == 4
     @test eltype(ordinal) == Int
     @test neighbors(ordinal) == SVector(0, 0, 0, 1)
+    @test center(ordinal) == 0
     @test sum(neighbors(ordinal)) == sum(ordinal) == 1
     ordinal2 = Ordinal{2}()
     @test offsets(ordinal2) == SVector((-2, -2), (2, -2), (-2, 2), (2, 2))
@@ -115,7 +117,7 @@ end
 @testset "Cardinal" begin
     h = Cardinal{1}()
     A = StencilArray(init, h)
-    cardinal = Stencils.rebuild(h, neighbors(A, (2, 2)))
+    cardinal = Stencils.rebuild(h, neighbors(A, (2, 2)), 0)
     @test offsets(cardinal) == SVector((0, -1), (-1, 0), (1, 0), (0, 1))
     @test radius(cardinal) == 1
     @test diameter(cardinal) == 3
@@ -124,6 +126,7 @@ end
     @test length(cardinal) == 4
     @test eltype(cardinal) == Int
     @test neighbors(cardinal) == SVector(1, 0, 1, 1)
+    @test center(cardinal) == 0
     @test sum(neighbors(cardinal)) == sum(cardinal) == 3
     cardinal2 = Cardinal{2}()
     @test offsets(cardinal2) == SVector((0, -2), (-2, 0), (2, 0), (0, 2))

--- a/test/stencils.jl
+++ b/test/stencils.jl
@@ -172,9 +172,9 @@ end
     A = StencilArray(collect(reshape(1:25, 5, 5)), multi_layered)
     ml_filled = stencil(A, (3, 3))
     @test ml_filled.l2.a == [7, 19]
-    mapstencil(A) do l
-        sum(l.l1.b) - sum(l.l2.a)
-    end
+    # mapstencil(A) do l
+    #     sum(l.l1.b) - sum(l.l2.a)
+    # end
 end
 
 @testset "Kernel" begin
@@ -199,7 +199,7 @@ end
         @test kernelproduct(k) === sum(vals .^ 2)
         # Nested arrays work too
         vals2 = map(x -> SVector((x, 2x)), vals)
-        k2 = Kernel(Moore{1,2}(vals2, 4), vals)
+        k2 = Kernel(Moore{1,2}(vals2, SVector(4,8)), vals)
         @test kernelproduct(k2) === sum(map((v2, v) -> v2 .* v, vals2, vals))
     end
     @testset "Positional" begin

--- a/test/stencils.jl
+++ b/test/stencils.jl
@@ -185,7 +185,7 @@ end
         @test Kernel(Window{1,2}(), SMatrix{3,3}(reshape(1:9, 3, 3))) == 
             Kernel(SMatrix{3,3}(reshape(1:9, 3, 3)))
             Kernel(reshape(1:9, 3, 3))
-        k = Kernel(Window{1,2}(kern), SMatrix{3,3}(reshape(1:9, 3, 3)))
+        k = Kernel(Window{1,2}(5, kern), SMatrix{3,3}(reshape(1:9, 3, 3)))
         @test kernelproduct(k) == sum((1:9).^2)
         @test neighbors(k) == SVector{9}(1:9)
         @test offsets(k) === SVector((-1, -1), (0, -1), (1, -1), (-1, 0), (0, 0),
@@ -195,11 +195,11 @@ end
     end
     @testset "Moore" begin
         vals = SVector(1:4..., 6:9...)
-        k = Kernel(Moore{1,2}(vals), vals)
+        k = Kernel(Moore{1,2}(4, vals), vals)
         @test kernelproduct(k) === sum(vals .^ 2)
         # Nested arrays work too
         vals2 = map(x -> SVector((x, 2x)), vals)
-        k2 = Kernel(Moore{1,2}(vals2), vals)
+        k2 = Kernel(Moore{1,2}(4, vals2), vals)
         @test kernelproduct(k2) === sum(map((v2, v) -> v2 .* v, vals2, vals))
     end
     @testset "Positional" begin

--- a/test/stencils.jl
+++ b/test/stencils.jl
@@ -12,7 +12,7 @@ win2 = SA[1, 1, 1, 1, 0, 1, 1, 1, 1]
 win3 = SA[1, 1, 1, 0, 0, 1, 0, 0, 1]
 
 @testset "Moore" begin
-    moore = Moore{1,2}(SVector(0,1,0,0,1,0,1,1))
+    moore = Moore{1,2}(1, SVector(0,1,0,0,1,0,1,1))
     @test isbits(moore)
 
     # Stencils.distance_zones(moore)
@@ -34,7 +34,7 @@ end
 
 @testset "Window" begin
     @test Window{1}() == Window{1,2}()
-    window = Window{1}(SVector(init[1:3, 1:3]...))
+    window = Window{1}(1, SVector(init[1:3, 1:3]...))
     @test isbits(window)
     @test diameter(window) == 3
     @test window[1] == 0
@@ -46,18 +46,18 @@ end
     @test offsets(window) == SVector((-1, -1), (0, -1), (1, -1), (-1, 0), (0, 0),
                                      (1, 0), (-1, 1), (0, 1), (1, 1))
 
-    window2 = Stencils.rebuild(window, SVector(win2...))
+    window2 = Stencils.rebuild(window, 1, SVector(win2...))
     @test neighbors(window2) == SVector(win2...)
 
-    @test sum(Window{1}(win1)) == 1
-    @test sum(Window{1}(win2)) == 8
-    @test sum(Window{1}(win3)) == 5
+    @test sum(Window{1}(1, win1)) == 1
+    @test sum(Window{1}(1, win2)) == 8
+    @test sum(Window{1}(1, win3)) == 5
 end
 
 @testset "VonNeumann" begin
     h = VonNeumann{1}()
     A = StencilArray(init, h)
-    vonneumann = Stencils.rebuild(h, neighbors(A, (2, 2))) 
+    vonneumann = Stencils.rebuild(h, 1, neighbors(A, (2, 2))) 
     @test offsets(vonneumann) == SVector((0, -1), (-1, 0), (1, 0), (0, 1))
     @test radius(vonneumann) == 1
     @test diameter(vonneumann) == 3
@@ -207,7 +207,7 @@ end
         off = ((0,-1),(-1,0),(1,0),(0,1))
         hood = Positional{off,1,2,4,}()
         vals = SVector(map(I -> win[I...], indices(hood, (2, 2))))
-        k = Stencils.rebuild(Kernel(hood, 1:4), vals)
+        k = Stencils.rebuild(Kernel(hood, 1:4), 1, vals)
         @test kernelproduct(k) === 1 * 2 + 2 * 4 + 3 * 6 + 4 * 8 === 60
     end
     @testset "Adapt" begin

--- a/test/stencils.jl
+++ b/test/stencils.jl
@@ -172,9 +172,9 @@ end
     A = StencilArray(collect(reshape(1:25, 5, 5)), multi_layered)
     ml_filled = stencil(A, (3, 3))
     @test ml_filled.l2.a == [7, 19]
-    # mapstencil(A) do l
-    #     sum(l.l1.b) - sum(l.l2.a)
-    # end
+    mapstencil(A) do l
+        sum(l.l1.b) - sum(l.l2.a)
+    end
 end
 
 @testset "Kernel" begin


### PR DESCRIPTION
Fixes #57.

I had to split the stencil constructors to prevent ambiguity errors with StaticArrays. I do see that I miss some constructors now for nested arrays, the interface is quite large.

Currently I run into an error with the multi nested layers, I could use some help with that, even Cthulhu is not helping me. Could be a wrong constructor somewhere.

```julia
julia> mapstencil(A) do l
           sum(l.l1.b) - sum(l.l2.a)
       end
ERROR: ArgumentError: cannot convert a value to Union{} for assignment
Stacktrace:
  [1] convert(T::Type{Union{}}, x::Int64)
    @ Base ./essentials.jl:455
  [2] setindex!
    @ ./array.jl:994 [inlined]
  [3] setindex!
    @ ./multidimensional.jl:704 [inlined]
  [4] macro expansion
    @ ~/code/Stencils.jl/src/mapstencil.jl:112 [inlined]
  [5] cpu_mapstencil_kerneln0!
    @ ~/.julia/packages/KernelAbstractions/0r40T/src/macros.jl:293 [inlined]
  [6] cpu_mapstencil_kerneln0!(__ctx__::KernelAbstractions.CompilerMetadata{…}, f::var"#11#12", dest::Matrix{…}, source::StencilArray{…})
    @ Stencils ./none:0
  [7] __thread_run(tid::Int64, len::Int64, rem::Int64, obj::KernelAbstractions.Kernel{…}, ndrange::Nothing, iterspace::KernelAbstractions.NDIteration.NDRange{…}, args::Tuple{…}, dynamic::KernelAbstractions.NDIteration.DynamicCheck)
    @ KernelAbstractions ~/.julia/packages/KernelAbstractions/0r40T/src/cpu.jl:142
  [8] __run(obj::KernelAbstractions.Kernel{…}, ndrange::Nothing, iterspace::KernelAbstractions.NDIteration.NDRange{…}, args::Tuple{…}, dynamic::KernelAbstractions.NDIteration.DynamicCheck, static_threads::Bool)
    @ KernelAbstractions ~/.julia/packages/KernelAbstractions/0r40T/src/cpu.jl:109
  [9] (::KernelAbstractions.Kernel{…})(::Function, ::Vararg{…}; ndrange::Nothing, workgroupsize::Nothing)
    @ KernelAbstractions ~/.julia/packages/KernelAbstractions/0r40T/src/cpu.jl:44
 [10] Kernel
    @ ~/.julia/packages/KernelAbstractions/0r40T/src/cpu.jl:37 [inlined]
 [11] mapstencil!(::Function, ::Matrix{…}, ::StencilArray{…})
    @ Stencils ~/code/Stencils.jl/src/mapstencil.jl:102
 [12] mapstencil(::Function, ::StencilArray{Tuple{…}, 2, Int64, 2, Matrix{…}, Layered{…}, Remove{…}, Conditional})
    @ Stencils ~/code/Stencils.jl/src/mapstencil.jl:18
 [13] top-level scope
    @ REPL[9]:1
Some type information was truncated. Use `show(err)` to see complete types.

```

