### PR TITLE
rename mapstencil to gatherstencil

### DIFF
--- a/src/Stencils.jl
+++ b/src/Stencils.jl
@@ -19,7 +19,7 @@ export Remove, Use, Wrap, Reflect
 export Conditional, Halo
 
 export stencil, neighbors, center, offsets, indices, distances, kernelproduct, radius, diameter
-export mapstencil, mapstencil!, scatterstencil!, switch
+export gatherstencil, gatherstencil!, mapstencil, mapstencil!, scatterstencil!, switch
 
 include("stencil.jl")
 include("stencils/window.jl")
@@ -35,7 +35,7 @@ include("stencils/named.jl")
 include("boundary.jl")
 include("padding.jl")
 include("array.jl")
-include("mapstencil.jl")
+include("gatherstencil.jl")
 include("scatterstencil.jl")
 
 end # Module Stencils

--- a/src/gatherstencil.jl
+++ b/src/gatherstencil.jl
@@ -1,26 +1,26 @@
 """
-    mapstencil(f, A::StencilArray, args::AbstractArray...)
-    mapstencil(f, stencil::Stencil, A::AbstractArray, args::AbstractArray...; kw...)
+    gatherstencil(f, A::StencilArray, args::AbstractArray...)
+    gatherstencil(f, stencil::Stencil, A::AbstractArray, args::AbstractArray...; kw...)
 
 Stencil mapping where `f` is passed a [`Stencil`](@ref) centered at each
 index in `A`, followed by the values from `args` at each stencil center.
 
 ## Keywords
 
-$STENCILARRAY_KEYWORDS 
+$STENCILARRAY_KEYWORDS
 
 The result is returned as a new array.
 """
-function mapstencil(
+function gatherstencil(
     f::F, source::AbstractStencilArray{<:Any,T,N}, args::AbstractArray...
 ) where {F,T,N}
     _checksizes((source, args...))
     T_return = _return_type(f, source, args...)
     dest = similar(parent(source), T_return, size(source))
-    return mapstencil!(f, dest, source, args...)
+    return gatherstencil!(f, dest, source, args...)
 end
-function mapstencil(
-    f::F, hood::StencilOrLayered, A::AbstractArray, args::AbstractArray...; 
+function gatherstencil(
+    f::F, hood::StencilOrLayered, A::AbstractArray, args::AbstractArray...;
     kw...
 ) where F
     sa = StencilArray(A, hood; kw...)
@@ -35,7 +35,7 @@ function mapstencil(
     else
         similar(A, T_return)
     end
-    return mapstencil!(f, dest, sa, args...)
+    return gatherstencil!(f, dest, sa, args...)
 end
 
 function _return_type(f::F, A::AbstractStencilArray{<:Any,T}, args...) where {F,T}
@@ -61,8 +61,8 @@ _zero_center(::Type{T}, ::Stencil) where T = zero(T)
 kernel_setup() = KernelAbstractions.CPU(; static=true), 64
 
 """
-    mapstencil!(f, dest::AbstractArray, source::StencilArray, args::AbstractArray...)
-    mapstencil!(f, A::SwitchingStencilArray, args::AbstractArray...)
+    gatherstencil!(f, dest::AbstractArray, source::StencilArray, args::AbstractArray...)
+    gatherstencil!(f, A::SwitchingStencilArray, args::AbstractArray...)
 
 Stencil mapping where `f` is passed a stencil centered at each index
 in `src`, followed by the values from `args` at each stencil center.
@@ -74,19 +74,19 @@ returning a switched version of the array.
 `dest` must either be smaller than `src` by the stencil radius on all
 sides, or be the same size, in which case it is assumed to also be padded.
 """
-function mapstencil!(f::F, A::SwitchingStencilArray, args::AbstractArray...) where F
+function gatherstencil!(f::F, A::SwitchingStencilArray, args::AbstractArray...) where F
     pd = padding(A) isa Halo ? Halo{:in}() : padding(A)
     src = StencilArray(source(A), stencil(A), boundary(A), pd)
     dst = StencilArray(dest(A), stencil(A), boundary(A), pd)
-    mapstencil!(f, dst, src, args...)
+    gatherstencil!(f, dst, src, args...)
     return switch(A)
 end
-function mapstencil!(f::F, A::SwitchingStencilArray, B::AbstractStencilArray, args::AbstractArray...) where F
+function gatherstencil!(f::F, A::SwitchingStencilArray, B::AbstractStencilArray, args::AbstractArray...) where F
     dst = StencilArray(dest(A), stencil(A), boundary(A), padding(A))
-    mapstencil!(f, dst, A, B, args...)
+    gatherstencil!(f, dst, A, B, args...)
     return switch(A)
 end
-function mapstencil!(
+function gatherstencil!(
     f::F, dest, source::AbstractStencilArray, args::AbstractArray...
 ) where F
     _checksizes((dest, source, args...))
@@ -95,14 +95,14 @@ function mapstencil!(
     foreach(a -> a isa AbstractStencilArray && update_boundary!(a), args)
 
     backend = KernelAbstractions.get_backend(parent(source))
-    kernel! = mapstencil_kernel!(backend)
+    kernel! = gatherstencil_kernel!(backend)
     kernel!(f, dest, source, args; ndrange=size(dest))
     KernelAbstractions.synchronize(backend)
 
     return dest
 end
 
-@kernel function mapstencil_kernel!(f::F, dest, source, args) where F
+@kernel function gatherstencil_kernel!(f::F, dest, source, args) where F
     I = @index(Global, Cartesian)
     @inbounds dest[I] = f(stencil(source, I), _getarg.(args, (I,))...)
     nothing
@@ -122,3 +122,7 @@ function _checksizes(sources::Tuple)
     end
     return nothing
 end
+
+# Deprecations
+Base.@deprecate mapstencil(args...; kw...) gatherstencil(args...; kw...)
+Base.@deprecate mapstencil!(args...) gatherstencil!(args...)


### PR DESCRIPTION
For symmetry with scatterstencil. `mapstencil` is deprecated.